### PR TITLE
Release main/Smdn.Fundamental.ByteString-3.0.2

### DIFF
--- a/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-net45.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.ByteString.dll (Smdn.Fundamental.ByteString-3.0.1 (net45))
+// Smdn.Fundamental.ByteString.dll (Smdn.Fundamental.ByteString-3.0.2)
 //   Name: Smdn.Fundamental.ByteString
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (net45)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+e1cdf5b57693d8430e0ef803045395521eb5d6f5
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 
@@ -172,7 +172,7 @@ namespace Smdn.Text {
     public static bool StartsWith(this ReadOnlySequence<byte> sequence, ReadOnlySpan<byte> @value) {}
     [Obsolete("use Smdn.Buffers.ReadOnlySequenceExtensions.SequenceEqualIgnoreCase instead", true)]
     public static byte[] ToArrayUpperCase(this ReadOnlySequence<byte> sequence) {}
-    [Obsolete]
+    [Obsolete("ByteString will be deprecated in future.")]
     public static ByteString ToByteString(this ReadOnlySequence<byte> sequence) {}
   }
 }

--- a/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-netstandard1.6.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.ByteString.dll (Smdn.Fundamental.ByteString-3.0.1 (netstandard1.6))
+// Smdn.Fundamental.ByteString.dll (Smdn.Fundamental.ByteString-3.0.2)
 //   Name: Smdn.Fundamental.ByteString
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (netstandard1.6)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+e1cdf5b57693d8430e0ef803045395521eb5d6f5
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 
@@ -172,7 +172,7 @@ namespace Smdn.Text {
     public static bool StartsWith(this ReadOnlySequence<byte> sequence, ReadOnlySpan<byte> @value) {}
     [Obsolete("use Smdn.Buffers.ReadOnlySequenceExtensions.SequenceEqualIgnoreCase instead", true)]
     public static byte[] ToArrayUpperCase(this ReadOnlySequence<byte> sequence) {}
-    [Obsolete]
+    [Obsolete("ByteString will be deprecated in future.")]
     public static ByteString ToByteString(this ReadOnlySequence<byte> sequence) {}
   }
 }

--- a/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.ByteString.dll (Smdn.Fundamental.ByteString-3.0.1 (netstandard2.1))
+// Smdn.Fundamental.ByteString.dll (Smdn.Fundamental.ByteString-3.0.2)
 //   Name: Smdn.Fundamental.ByteString
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (netstandard2.1)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+e1cdf5b57693d8430e0ef803045395521eb5d6f5
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
@@ -172,7 +172,7 @@ namespace Smdn.Text {
     public static bool StartsWith(this ReadOnlySequence<byte> sequence, ReadOnlySpan<byte> @value) {}
     [Obsolete("use Smdn.Buffers.ReadOnlySequenceExtensions.SequenceEqualIgnoreCase instead", true)]
     public static byte[] ToArrayUpperCase(this ReadOnlySequence<byte> sequence) {}
-    [Obsolete]
+    [Obsolete("ByteString will be deprecated in future.")]
     public static ByteString ToByteString(this ReadOnlySequence<byte> sequence) {}
   }
 }


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #17](https://github.com/smdn/Smdn.Fundamentals/actions/runs/1871973682).

# Release target
## Release target info
- package_target_tag: `new-release/main/Smdn.Fundamental.ByteString-3.0.2`
- package_id: `Smdn.Fundamental.ByteString`
- package_id_with_version: `Smdn.Fundamental.ByteString-3.0.2`
- package_version: `3.0.2`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.ByteString-3.0.2-1645362477`
- release_tag: `releases/Smdn.Fundamental.ByteString-3.0.2`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- artifact_name_nupkg: `Smdn.Fundamental.ByteString.3.0.2.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

## .nuspec
```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.ByteString</id>
    <version>3.0.2</version>
    <title>Smdn.Fundamental.ByteString</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.ByteString.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.ByteString.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp string array buffer ByteString</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="e1cdf5b57693d8430e0ef803045395521eb5d6f5" />
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="Smdn.Fundamental.Buffer" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="Smdn.Fundamental.Buffer" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
        <dependency id="System.Runtime.Serialization.Formatters" version="4.3.0" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.1">
        <dependency id="Smdn.Fundamental.Buffer" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.ByteString/bin/Release/net45/Smdn.Fundamental.ByteString.dll" target="lib/net45/Smdn.Fundamental.ByteString.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.ByteString/bin/Release/netstandard1.6/Smdn.Fundamental.ByteString.dll" target="lib/netstandard1.6/Smdn.Fundamental.ByteString.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.ByteString/bin/Release/netstandard2.1/Smdn.Fundamental.ByteString.dll" target="lib/netstandard2.1/Smdn.Fundamental.ByteString.dll" />
    <file src="/home/runner/.nuget/packages/smdn.msbuild.projectassets.common/1.1.0/project/images/package-icon.png" target="Smdn.Fundamental.ByteString.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.ByteString/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

<!-- RELEASE NOTE -->
# Packages
- NuGet [Smdn.Fundamental.ByteString version 3.0.2](https://www.nuget.org/packages/Smdn.Fundamental.ByteString/3.0.2)

# Changes in this release
## Change log
- 2022-02-20 [update assembly version](https://github.com/smdn/Smdn.Fundamentals/commit/e1cdf5b57693d8430e0ef803045395521eb5d6f5)
- 2022-02-04 [add obsolete message](https://github.com/smdn/Smdn.Fundamentals/commit/f7fa73e884e36efc4adedcc5adaeeb3049138971)
- 2022-02-04 [suppress warning CA2201](https://github.com/smdn/Smdn.Fundamentals/commit/96396bd22c32b55d38dcad4fa5b45ef4e4e2f343)
- 2022-02-04 [use string.ToLowerInvariant() instead](https://github.com/smdn/Smdn.Fundamentals/commit/bdc965046225250d755fbf11cd6b90f9ab40ba50)
- 2022-01-02 [define PackageTags](https://github.com/smdn/Smdn.Fundamentals/commit/81012f2f141eeeb5a771c348155efde8b13addd7)
- 2022-01-02 [refactor assembly attributes and package properties](https://github.com/smdn/Smdn.Fundamentals/commit/fb53ac2436caadd4dc156bb9e928250d5834e793)

## API diff
<details>
<summary>API diff in this release</summary>
<div>

```diff
diff --git a/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-net45.apilist.cs b/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-net45.apilist.cs
index 630c87c9..1bd1f1ce 100644
--- a/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-net45.apilist.cs
@@ -1,179 +1,179 @@
-// Smdn.Fundamental.ByteString.dll (Smdn.Fundamental.ByteString-3.0.1 (net45))
+// Smdn.Fundamental.ByteString.dll (Smdn.Fundamental.ByteString-3.0.2)
 //   Name: Smdn.Fundamental.ByteString
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (net45)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+e1cdf5b57693d8430e0ef803045395521eb5d6f5
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 
 using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Text;
 using Smdn.Text;
 
 namespace Smdn.Text {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [Serializable]
   public class ByteString :
     IEquatable<ArraySegment<byte>>,
     IEquatable<ByteString>,
     IEquatable<byte[]>,
     IEquatable<string>,
     ISerializable
   {
     protected ByteString(SerializationInfo info, StreamingContext context) {}
     public ByteString(ArraySegment<byte> segment, bool asMutable) {}
     public ByteString(string @value, bool asMutable) {}
 
     public byte this[int index] { get; set; }
     public bool IsEmpty { get; }
     public bool IsMutable { get; }
     public int Length { get; }
     public ArraySegment<byte> Segment { get; }
 
     public static ByteString Concat(bool asMutable, params ByteString[] values) {}
     public static ByteString Concat(params ByteString[] values) {}
     public static ByteString ConcatImmutable(params ByteString[] values) {}
     public static ByteString ConcatMutable(params ByteString[] values) {}
     public bool Contains(ByteString @value) {}
     public bool Contains(byte[] @value) {}
     public void CopyTo(byte[] dest) {}
     public void CopyTo(byte[] dest, int destOffset) {}
     public void CopyTo(byte[] dest, int destOffset, int count) {}
     public void CopyTo(int startIndex, byte[] dest) {}
     public void CopyTo(int startIndex, byte[] dest, int destOffset) {}
     public void CopyTo(int startIndex, byte[] dest, int destOffset, int count) {}
     public static ByteString Create(bool asMutable, byte[] @value, int offset) {}
     public static ByteString Create(bool asMutable, byte[] @value, int offset, int count) {}
     public static ByteString Create(bool asMutable, params byte[] @value) {}
     public static ByteString CreateEmpty() {}
     public static ByteString CreateImmutable(byte[] @value, int offset) {}
     public static ByteString CreateImmutable(byte[] @value, int offset, int count) {}
     public static ByteString CreateImmutable(params byte[] @value) {}
     public static ByteString CreateImmutable(string str) {}
     public static ByteString CreateImmutable(string str, int startIndex, int count) {}
     public static ByteString CreateMutable(byte[] @value, int offset) {}
     public static ByteString CreateMutable(byte[] @value, int offset, int count) {}
     public static ByteString CreateMutable(params byte[] @value) {}
     public static ByteString CreateMutable(string str) {}
     public static ByteString CreateMutable(string str, int startIndex, int count) {}
     public bool EndsWith(ArraySegment<byte> @value) {}
     public bool EndsWith(ByteString @value) {}
     public bool EndsWith(byte[] @value) {}
     public bool EndsWith(string @value) {}
     public bool Equals(ArraySegment<byte> other) {}
     public bool Equals(ByteString other) {}
     public bool Equals(byte[] other) {}
     public bool Equals(string other) {}
     public override bool Equals(object obj) {}
     public bool EqualsIgnoreCase(ByteString other) {}
     public bool EqualsIgnoreCase(string other) {}
     public override int GetHashCode() {}
     public void GetObjectData(SerializationInfo info, StreamingContext context) {}
     public IEnumerable<ByteString> GetSplittedSubstrings(byte delimiter) {}
     public IEnumerable<ByteString> GetSplittedSubstrings(char delimiter) {}
     public ArraySegment<byte> GetSubSegment(int startIndex) {}
     public ArraySegment<byte> GetSubSegment(int startIndex, int count) {}
     public int IndexOf(ArraySegment<byte> @value) {}
     public int IndexOf(ArraySegment<byte> @value, int startIndex) {}
     public int IndexOf(ByteString @value) {}
     public int IndexOf(ByteString @value, int startIndex) {}
     public int IndexOf(byte @value) {}
     public int IndexOf(byte @value, int startIndex) {}
     public int IndexOf(byte[] @value) {}
     public int IndexOf(byte[] @value, int startIndex) {}
     public int IndexOf(char @value) {}
     public int IndexOf(char @value, int startIndex) {}
     public int IndexOf(string @value) {}
     public int IndexOf(string @value, int startIndex) {}
     public int IndexOfIgnoreCase(ArraySegment<byte> @value) {}
     public int IndexOfIgnoreCase(ArraySegment<byte> @value, int startIndex) {}
     public int IndexOfIgnoreCase(ByteString @value) {}
     public int IndexOfIgnoreCase(ByteString @value, int startIndex) {}
     public int IndexOfIgnoreCase(byte[] @value) {}
     public int IndexOfIgnoreCase(byte[] @value, int startIndex) {}
     public int IndexOfNot(byte @value) {}
     public int IndexOfNot(byte @value, int startIndex) {}
     public int IndexOfNot(char @value) {}
     public int IndexOfNot(char @value, int startIndex) {}
     public static bool IsNullOrEmpty(ByteString str) {}
     public bool IsPrefixOf(ArraySegment<byte> @value) {}
     public bool IsPrefixOf(ByteString @value) {}
     public bool IsPrefixOf(byte[] @value) {}
     public static bool IsTerminatedByCRLF(ByteString str) {}
     public ByteString[] Split(byte delimiter) {}
     public ByteString[] Split(char delimiter) {}
     public bool StartsWith(ArraySegment<byte> @value) {}
     public bool StartsWith(ByteString @value) {}
     public bool StartsWith(byte[] @value) {}
     public bool StartsWith(string @value) {}
     public bool StartsWithIgnoreCase(ArraySegment<byte> @value) {}
     public bool StartsWithIgnoreCase(ByteString @value) {}
     public bool StartsWithIgnoreCase(byte[] @value) {}
     public ByteString Substring(int startIndex) {}
     public ByteString Substring(int startIndex, int count) {}
     public byte[] ToArray() {}
     public byte[] ToArray(int startIndex) {}
     public byte[] ToArray(int startIndex, int count) {}
     public static byte[] ToByteArray(string @value) {}
     public static byte[] ToByteArray(string @value, int startIndex, int count) {}
     public ByteString ToLower() {}
     public override string ToString() {}
     public static string ToString(ReadOnlySequence<byte> sequence, Encoding encoding = null) {}
     public string ToString(Encoding encoding) {}
     public string ToString(Encoding encoding, int startIndex) {}
     public string ToString(Encoding encoding, int startIndex, int count) {}
     public string ToString(int startIndex) {}
     public string ToString(int startIndex, int count) {}
     public uint ToUInt32() {}
     public ulong ToUInt64() {}
     public ByteString ToUpper() {}
     public ByteString Trim() {}
     public ByteString TrimEnd() {}
     public ByteString TrimStart() {}
     public static ByteString operator + (ByteString x, ByteString y) {}
     public static bool operator == (ByteString x, ByteString y) {}
     public static bool operator != (ByteString x, ByteString y) {}
     public static ByteString operator * (ByteString x, int y) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class ByteStringBuilder {
     public ByteStringBuilder() {}
     public ByteStringBuilder(int capacity) {}
     public ByteStringBuilder(int capacity, int maxCapacity) {}
 
     public byte this[int index] { get; set; }
     public int Capacity { get; }
     public int Length { get; set; }
     public int MaxCapacity { get; }
 
     public ByteStringBuilder Append(ArraySegment<byte> segment) {}
     public ByteStringBuilder Append(ByteString str) {}
     public ByteStringBuilder Append(ByteString str, int startIndex, int count) {}
     public ByteStringBuilder Append(byte b) {}
     public ByteStringBuilder Append(byte[] str) {}
     public ByteStringBuilder Append(byte[] str, int startIndex, int count) {}
     public ByteStringBuilder Append(string str) {}
     public ArraySegment<byte> GetSegment() {}
     public ArraySegment<byte> GetSegment(int offset, int count) {}
     public byte[] ToByteArray() {}
     public ByteString ToByteString(bool asMutable) {}
     public override string ToString() {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class ByteStringExtensions {
     public static ReadOnlySequence<byte> AsReadOnlySequence(this ByteString str) {}
     [Obsolete("use Smdn.Buffers.ReadOnlySequenceExtensions.SequenceEqual instead")]
     public static bool SequenceEqual(this ReadOnlySequence<byte> sequence, ReadOnlySpan<byte> @value) {}
     [Obsolete("use Smdn.Buffers.ReadOnlySequenceExtensions.StartsWith instead")]
     public static bool StartsWith(this ReadOnlySequence<byte> sequence, ReadOnlySpan<byte> @value) {}
     [Obsolete("use Smdn.Buffers.ReadOnlySequenceExtensions.SequenceEqualIgnoreCase instead", true)]
     public static byte[] ToArrayUpperCase(this ReadOnlySequence<byte> sequence) {}
-    [Obsolete]
+    [Obsolete("ByteString will be deprecated in future.")]
     public static ByteString ToByteString(this ReadOnlySequence<byte> sequence) {}
   }
 }
 
diff --git a/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-netstandard1.6.apilist.cs b/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-netstandard1.6.apilist.cs
index 11342316..c0a0c892 100644
--- a/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-netstandard1.6.apilist.cs
@@ -1,179 +1,179 @@
-// Smdn.Fundamental.ByteString.dll (Smdn.Fundamental.ByteString-3.0.1 (netstandard1.6))
+// Smdn.Fundamental.ByteString.dll (Smdn.Fundamental.ByteString-3.0.2)
 //   Name: Smdn.Fundamental.ByteString
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (netstandard1.6)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+e1cdf5b57693d8430e0ef803045395521eb5d6f5
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 
 using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Text;
 using Smdn.Text;
 
 namespace Smdn.Text {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [Serializable]
   public class ByteString :
     IEquatable<ArraySegment<byte>>,
     IEquatable<ByteString>,
     IEquatable<byte[]>,
     IEquatable<string>,
     ISerializable
   {
     protected ByteString(SerializationInfo info, StreamingContext context) {}
     public ByteString(ArraySegment<byte> segment, bool asMutable) {}
     public ByteString(string @value, bool asMutable) {}
 
     public byte this[int index] { get; set; }
     public bool IsEmpty { get; }
     public bool IsMutable { get; }
     public int Length { get; }
     public ArraySegment<byte> Segment { get; }
 
     public static ByteString Concat(bool asMutable, params ByteString[] values) {}
     public static ByteString Concat(params ByteString[] values) {}
     public static ByteString ConcatImmutable(params ByteString[] values) {}
     public static ByteString ConcatMutable(params ByteString[] values) {}
     public bool Contains(ByteString @value) {}
     public bool Contains(byte[] @value) {}
     public void CopyTo(byte[] dest) {}
     public void CopyTo(byte[] dest, int destOffset) {}
     public void CopyTo(byte[] dest, int destOffset, int count) {}
     public void CopyTo(int startIndex, byte[] dest) {}
     public void CopyTo(int startIndex, byte[] dest, int destOffset) {}
     public void CopyTo(int startIndex, byte[] dest, int destOffset, int count) {}
     public static ByteString Create(bool asMutable, byte[] @value, int offset) {}
     public static ByteString Create(bool asMutable, byte[] @value, int offset, int count) {}
     public static ByteString Create(bool asMutable, params byte[] @value) {}
     public static ByteString CreateEmpty() {}
     public static ByteString CreateImmutable(byte[] @value, int offset) {}
     public static ByteString CreateImmutable(byte[] @value, int offset, int count) {}
     public static ByteString CreateImmutable(params byte[] @value) {}
     public static ByteString CreateImmutable(string str) {}
     public static ByteString CreateImmutable(string str, int startIndex, int count) {}
     public static ByteString CreateMutable(byte[] @value, int offset) {}
     public static ByteString CreateMutable(byte[] @value, int offset, int count) {}
     public static ByteString CreateMutable(params byte[] @value) {}
     public static ByteString CreateMutable(string str) {}
     public static ByteString CreateMutable(string str, int startIndex, int count) {}
     public bool EndsWith(ArraySegment<byte> @value) {}
     public bool EndsWith(ByteString @value) {}
     public bool EndsWith(byte[] @value) {}
     public bool EndsWith(string @value) {}
     public bool Equals(ArraySegment<byte> other) {}
     public bool Equals(ByteString other) {}
     public bool Equals(byte[] other) {}
     public bool Equals(string other) {}
     public override bool Equals(object obj) {}
     public bool EqualsIgnoreCase(ByteString other) {}
     public bool EqualsIgnoreCase(string other) {}
     public override int GetHashCode() {}
     public void GetObjectData(SerializationInfo info, StreamingContext context) {}
     public IEnumerable<ByteString> GetSplittedSubstrings(byte delimiter) {}
     public IEnumerable<ByteString> GetSplittedSubstrings(char delimiter) {}
     public ArraySegment<byte> GetSubSegment(int startIndex) {}
     public ArraySegment<byte> GetSubSegment(int startIndex, int count) {}
     public int IndexOf(ArraySegment<byte> @value) {}
     public int IndexOf(ArraySegment<byte> @value, int startIndex) {}
     public int IndexOf(ByteString @value) {}
     public int IndexOf(ByteString @value, int startIndex) {}
     public int IndexOf(byte @value) {}
     public int IndexOf(byte @value, int startIndex) {}
     public int IndexOf(byte[] @value) {}
     public int IndexOf(byte[] @value, int startIndex) {}
     public int IndexOf(char @value) {}
     public int IndexOf(char @value, int startIndex) {}
     public int IndexOf(string @value) {}
     public int IndexOf(string @value, int startIndex) {}
     public int IndexOfIgnoreCase(ArraySegment<byte> @value) {}
     public int IndexOfIgnoreCase(ArraySegment<byte> @value, int startIndex) {}
     public int IndexOfIgnoreCase(ByteString @value) {}
     public int IndexOfIgnoreCase(ByteString @value, int startIndex) {}
     public int IndexOfIgnoreCase(byte[] @value) {}
     public int IndexOfIgnoreCase(byte[] @value, int startIndex) {}
     public int IndexOfNot(byte @value) {}
     public int IndexOfNot(byte @value, int startIndex) {}
     public int IndexOfNot(char @value) {}
     public int IndexOfNot(char @value, int startIndex) {}
     public static bool IsNullOrEmpty(ByteString str) {}
     public bool IsPrefixOf(ArraySegment<byte> @value) {}
     public bool IsPrefixOf(ByteString @value) {}
     public bool IsPrefixOf(byte[] @value) {}
     public static bool IsTerminatedByCRLF(ByteString str) {}
     public ByteString[] Split(byte delimiter) {}
     public ByteString[] Split(char delimiter) {}
     public bool StartsWith(ArraySegment<byte> @value) {}
     public bool StartsWith(ByteString @value) {}
     public bool StartsWith(byte[] @value) {}
     public bool StartsWith(string @value) {}
     public bool StartsWithIgnoreCase(ArraySegment<byte> @value) {}
     public bool StartsWithIgnoreCase(ByteString @value) {}
     public bool StartsWithIgnoreCase(byte[] @value) {}
     public ByteString Substring(int startIndex) {}
     public ByteString Substring(int startIndex, int count) {}
     public byte[] ToArray() {}
     public byte[] ToArray(int startIndex) {}
     public byte[] ToArray(int startIndex, int count) {}
     public static byte[] ToByteArray(string @value) {}
     public static byte[] ToByteArray(string @value, int startIndex, int count) {}
     public ByteString ToLower() {}
     public override string ToString() {}
     public static string ToString(ReadOnlySequence<byte> sequence, Encoding encoding = null) {}
     public string ToString(Encoding encoding) {}
     public string ToString(Encoding encoding, int startIndex) {}
     public string ToString(Encoding encoding, int startIndex, int count) {}
     public string ToString(int startIndex) {}
     public string ToString(int startIndex, int count) {}
     public uint ToUInt32() {}
     public ulong ToUInt64() {}
     public ByteString ToUpper() {}
     public ByteString Trim() {}
     public ByteString TrimEnd() {}
     public ByteString TrimStart() {}
     public static ByteString operator + (ByteString x, ByteString y) {}
     public static bool operator == (ByteString x, ByteString y) {}
     public static bool operator != (ByteString x, ByteString y) {}
     public static ByteString operator * (ByteString x, int y) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class ByteStringBuilder {
     public ByteStringBuilder() {}
     public ByteStringBuilder(int capacity) {}
     public ByteStringBuilder(int capacity, int maxCapacity) {}
 
     public byte this[int index] { get; set; }
     public int Capacity { get; }
     public int Length { get; set; }
     public int MaxCapacity { get; }
 
     public ByteStringBuilder Append(ArraySegment<byte> segment) {}
     public ByteStringBuilder Append(ByteString str) {}
     public ByteStringBuilder Append(ByteString str, int startIndex, int count) {}
     public ByteStringBuilder Append(byte b) {}
     public ByteStringBuilder Append(byte[] str) {}
     public ByteStringBuilder Append(byte[] str, int startIndex, int count) {}
     public ByteStringBuilder Append(string str) {}
     public ArraySegment<byte> GetSegment() {}
     public ArraySegment<byte> GetSegment(int offset, int count) {}
     public byte[] ToByteArray() {}
     public ByteString ToByteString(bool asMutable) {}
     public override string ToString() {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class ByteStringExtensions {
     public static ReadOnlySequence<byte> AsReadOnlySequence(this ByteString str) {}
     [Obsolete("use Smdn.Buffers.ReadOnlySequenceExtensions.SequenceEqual instead")]
     public static bool SequenceEqual(this ReadOnlySequence<byte> sequence, ReadOnlySpan<byte> @value) {}
     [Obsolete("use Smdn.Buffers.ReadOnlySequenceExtensions.StartsWith instead")]
     public static bool StartsWith(this ReadOnlySequence<byte> sequence, ReadOnlySpan<byte> @value) {}
     [Obsolete("use Smdn.Buffers.ReadOnlySequenceExtensions.SequenceEqualIgnoreCase instead", true)]
     public static byte[] ToArrayUpperCase(this ReadOnlySequence<byte> sequence) {}
-    [Obsolete]
+    [Obsolete("ByteString will be deprecated in future.")]
     public static ByteString ToByteString(this ReadOnlySequence<byte> sequence) {}
   }
 }
 
diff --git a/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-netstandard2.1.apilist.cs b/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-netstandard2.1.apilist.cs
index 98ade038..87a38331 100644
--- a/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString-netstandard2.1.apilist.cs
@@ -1,179 +1,179 @@
-// Smdn.Fundamental.ByteString.dll (Smdn.Fundamental.ByteString-3.0.1 (netstandard2.1))
+// Smdn.Fundamental.ByteString.dll (Smdn.Fundamental.ByteString-3.0.2)
 //   Name: Smdn.Fundamental.ByteString
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (netstandard2.1)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+e1cdf5b57693d8430e0ef803045395521eb5d6f5
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
 using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Text;
 using Smdn.Text;
 
 namespace Smdn.Text {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [Serializable]
   public class ByteString :
     IEquatable<ArraySegment<byte>>,
     IEquatable<ByteString>,
     IEquatable<byte[]>,
     IEquatable<string>,
     ISerializable
   {
     protected ByteString(SerializationInfo info, StreamingContext context) {}
     public ByteString(ArraySegment<byte> segment, bool asMutable) {}
     public ByteString(string @value, bool asMutable) {}
 
     public byte this[int index] { get; set; }
     public bool IsEmpty { get; }
     public bool IsMutable { get; }
     public int Length { get; }
     public ArraySegment<byte> Segment { get; }
 
     public static ByteString Concat(bool asMutable, params ByteString[] values) {}
     public static ByteString Concat(params ByteString[] values) {}
     public static ByteString ConcatImmutable(params ByteString[] values) {}
     public static ByteString ConcatMutable(params ByteString[] values) {}
     public bool Contains(ByteString @value) {}
     public bool Contains(byte[] @value) {}
     public void CopyTo(byte[] dest) {}
     public void CopyTo(byte[] dest, int destOffset) {}
     public void CopyTo(byte[] dest, int destOffset, int count) {}
     public void CopyTo(int startIndex, byte[] dest) {}
     public void CopyTo(int startIndex, byte[] dest, int destOffset) {}
     public void CopyTo(int startIndex, byte[] dest, int destOffset, int count) {}
     public static ByteString Create(bool asMutable, byte[] @value, int offset) {}
     public static ByteString Create(bool asMutable, byte[] @value, int offset, int count) {}
     public static ByteString Create(bool asMutable, params byte[] @value) {}
     public static ByteString CreateEmpty() {}
     public static ByteString CreateImmutable(byte[] @value, int offset) {}
     public static ByteString CreateImmutable(byte[] @value, int offset, int count) {}
     public static ByteString CreateImmutable(params byte[] @value) {}
     public static ByteString CreateImmutable(string str) {}
     public static ByteString CreateImmutable(string str, int startIndex, int count) {}
     public static ByteString CreateMutable(byte[] @value, int offset) {}
     public static ByteString CreateMutable(byte[] @value, int offset, int count) {}
     public static ByteString CreateMutable(params byte[] @value) {}
     public static ByteString CreateMutable(string str) {}
     public static ByteString CreateMutable(string str, int startIndex, int count) {}
     public bool EndsWith(ArraySegment<byte> @value) {}
     public bool EndsWith(ByteString @value) {}
     public bool EndsWith(byte[] @value) {}
     public bool EndsWith(string @value) {}
     public bool Equals(ArraySegment<byte> other) {}
     public bool Equals(ByteString other) {}
     public bool Equals(byte[] other) {}
     public bool Equals(string other) {}
     public override bool Equals(object obj) {}
     public bool EqualsIgnoreCase(ByteString other) {}
     public bool EqualsIgnoreCase(string other) {}
     public override int GetHashCode() {}
     public void GetObjectData(SerializationInfo info, StreamingContext context) {}
     public IEnumerable<ByteString> GetSplittedSubstrings(byte delimiter) {}
     public IEnumerable<ByteString> GetSplittedSubstrings(char delimiter) {}
     public ArraySegment<byte> GetSubSegment(int startIndex) {}
     public ArraySegment<byte> GetSubSegment(int startIndex, int count) {}
     public int IndexOf(ArraySegment<byte> @value) {}
     public int IndexOf(ArraySegment<byte> @value, int startIndex) {}
     public int IndexOf(ByteString @value) {}
     public int IndexOf(ByteString @value, int startIndex) {}
     public int IndexOf(byte @value) {}
     public int IndexOf(byte @value, int startIndex) {}
     public int IndexOf(byte[] @value) {}
     public int IndexOf(byte[] @value, int startIndex) {}
     public int IndexOf(char @value) {}
     public int IndexOf(char @value, int startIndex) {}
     public int IndexOf(string @value) {}
     public int IndexOf(string @value, int startIndex) {}
     public int IndexOfIgnoreCase(ArraySegment<byte> @value) {}
     public int IndexOfIgnoreCase(ArraySegment<byte> @value, int startIndex) {}
     public int IndexOfIgnoreCase(ByteString @value) {}
     public int IndexOfIgnoreCase(ByteString @value, int startIndex) {}
     public int IndexOfIgnoreCase(byte[] @value) {}
     public int IndexOfIgnoreCase(byte[] @value, int startIndex) {}
     public int IndexOfNot(byte @value) {}
     public int IndexOfNot(byte @value, int startIndex) {}
     public int IndexOfNot(char @value) {}
     public int IndexOfNot(char @value, int startIndex) {}
     public static bool IsNullOrEmpty(ByteString str) {}
     public bool IsPrefixOf(ArraySegment<byte> @value) {}
     public bool IsPrefixOf(ByteString @value) {}
     public bool IsPrefixOf(byte[] @value) {}
     public static bool IsTerminatedByCRLF(ByteString str) {}
     public ByteString[] Split(byte delimiter) {}
     public ByteString[] Split(char delimiter) {}
     public bool StartsWith(ArraySegment<byte> @value) {}
     public bool StartsWith(ByteString @value) {}
     public bool StartsWith(byte[] @value) {}
     public bool StartsWith(string @value) {}
     public bool StartsWithIgnoreCase(ArraySegment<byte> @value) {}
     public bool StartsWithIgnoreCase(ByteString @value) {}
     public bool StartsWithIgnoreCase(byte[] @value) {}
     public ByteString Substring(int startIndex) {}
     public ByteString Substring(int startIndex, int count) {}
     public byte[] ToArray() {}
     public byte[] ToArray(int startIndex) {}
     public byte[] ToArray(int startIndex, int count) {}
     public static byte[] ToByteArray(string @value) {}
     public static byte[] ToByteArray(string @value, int startIndex, int count) {}
     public ByteString ToLower() {}
     public override string ToString() {}
     public static string ToString(ReadOnlySequence<byte> sequence, Encoding encoding = null) {}
     public string ToString(Encoding encoding) {}
     public string ToString(Encoding encoding, int startIndex) {}
     public string ToString(Encoding encoding, int startIndex, int count) {}
     public string ToString(int startIndex) {}
     public string ToString(int startIndex, int count) {}
     public uint ToUInt32() {}
     public ulong ToUInt64() {}
     public ByteString ToUpper() {}
     public ByteString Trim() {}
     public ByteString TrimEnd() {}
     public ByteString TrimStart() {}
     public static ByteString operator + (ByteString x, ByteString y) {}
     public static bool operator == (ByteString x, ByteString y) {}
     public static bool operator != (ByteString x, ByteString y) {}
     public static ByteString operator * (ByteString x, int y) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class ByteStringBuilder {
     public ByteStringBuilder() {}
     public ByteStringBuilder(int capacity) {}
     public ByteStringBuilder(int capacity, int maxCapacity) {}
 
     public byte this[int index] { get; set; }
     public int Capacity { get; }
     public int Length { get; set; }
     public int MaxCapacity { get; }
 
     public ByteStringBuilder Append(ArraySegment<byte> segment) {}
     public ByteStringBuilder Append(ByteString str) {}
     public ByteStringBuilder Append(ByteString str, int startIndex, int count) {}
     public ByteStringBuilder Append(byte b) {}
     public ByteStringBuilder Append(byte[] str) {}
     public ByteStringBuilder Append(byte[] str, int startIndex, int count) {}
     public ByteStringBuilder Append(string str) {}
     public ArraySegment<byte> GetSegment() {}
     public ArraySegment<byte> GetSegment(int offset, int count) {}
     public byte[] ToByteArray() {}
     public ByteString ToByteString(bool asMutable) {}
     public override string ToString() {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class ByteStringExtensions {
     public static ReadOnlySequence<byte> AsReadOnlySequence(this ByteString str) {}
     [Obsolete("use Smdn.Buffers.ReadOnlySequenceExtensions.SequenceEqual instead")]
     public static bool SequenceEqual(this ReadOnlySequence<byte> sequence, ReadOnlySpan<byte> @value) {}
     [Obsolete("use Smdn.Buffers.ReadOnlySequenceExtensions.StartsWith instead")]
     public static bool StartsWith(this ReadOnlySequence<byte> sequence, ReadOnlySpan<byte> @value) {}
     [Obsolete("use Smdn.Buffers.ReadOnlySequenceExtensions.SequenceEqualIgnoreCase instead", true)]
     public static byte[] ToArrayUpperCase(this ReadOnlySequence<byte> sequence) {}
-    [Obsolete]
+    [Obsolete("ByteString will be deprecated in future.")]
     public static ByteString ToByteString(this ReadOnlySequence<byte> sequence) {}
   }
 }
 
```

</div>
</details>

## Changes
[Compare changes](https://github.com/smdn/Smdn.Fundamentals/compare/releases/Smdn.Fundamental.ByteString-3.0.1..releases/Smdn.Fundamental.ByteString-3.0.2)

<details>
<summary>Changes in this release</summary>
<div>

```diff
diff --git a/src/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString.csproj b/src/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString.csproj
index 437d638e..6319c105 100644
--- a/src/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString.csproj
+++ b/src/Smdn.Fundamental.ByteString/Smdn.Fundamental.ByteString.csproj
@@ -5,17 +5,18 @@ SPDX-License-Identifier: MIT
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.1;netstandard1.6</TargetFrameworks>
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <VersionPrefix>3.0.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup Label="metadata">
+  <PropertyGroup Label="assembly attributes">
     <CopyrightYear>2021</CopyrightYear>
+  </PropertyGroup>
 
-    <!-- NuGet -->
-    <!--<PackageTags></PackageTags>-->
+  <PropertyGroup Label="package properties">
+    <PackageTags>string;array;buffer;ByteString</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
diff --git a/src/Smdn.Fundamental.ByteString/Smdn.Text/ByteString.cs b/src/Smdn.Fundamental.ByteString/Smdn.Text/ByteString.cs
index 29bd9473..758813af 100644
--- a/src/Smdn.Fundamental.ByteString/Smdn.Text/ByteString.cs
+++ b/src/Smdn.Fundamental.ByteString/Smdn.Text/ByteString.cs
@@ -25,7 +25,10 @@ public class ByteString :
   public byte this[int index] {
     get {
       if (index < 0 || segment.Count <= index)
+#pragma warning disable CA2201
+        // TODO: throw ArgumentOutOfRangeException instead
         throw new IndexOutOfRangeException();
+#pragma warning restore CA2201
 
       return segment.Array[segment.Offset + index];
     }
@@ -947,7 +950,7 @@ public class ByteString :
     if (segment.Count != other.Length)
       return false;
 
-    return this.ToLower().Equals(other.ToLower()); // XXX
+    return this.ToLower().Equals(other.ToLowerInvariant()); // XXX
   }
 
   public static ByteString operator +(ByteString x, ByteString y)
diff --git a/src/Smdn.Fundamental.ByteString/Smdn.Text/ByteStringBuilder.cs b/src/Smdn.Fundamental.ByteString/Smdn.Text/ByteStringBuilder.cs
index daad6f28..d8f07753 100644
--- a/src/Smdn.Fundamental.ByteString/Smdn.Text/ByteStringBuilder.cs
+++ b/src/Smdn.Fundamental.ByteString/Smdn.Text/ByteStringBuilder.cs
@@ -10,7 +10,10 @@ public class ByteStringBuilder {
   public byte this[int index] {
     get {
       if (index < 0 || length <= index)
+#pragma warning disable CA2201
+        // TODO: throw ArgumentOutOfRangeException instead
         throw new IndexOutOfRangeException();
+#pragma warning restore CA2201
       return buffer[index];
     }
     set {
diff --git a/src/Smdn.Fundamental.ByteString/Smdn.Text/ByteStringExtensions.cs b/src/Smdn.Fundamental.ByteString/Smdn.Text/ByteStringExtensions.cs
index 170267b6..6c29336d 100644
--- a/src/Smdn.Fundamental.ByteString/Smdn.Text/ByteStringExtensions.cs
+++ b/src/Smdn.Fundamental.ByteString/Smdn.Text/ByteStringExtensions.cs
@@ -9,7 +9,7 @@ namespace Smdn.Text;
 public static class ByteStringExtensions {
   public static ReadOnlySequence<byte> AsReadOnlySequence(this ByteString str) => new(str.Segment.AsMemory());
 
-  [Obsolete]
+  [Obsolete("ByteString will be deprecated in future.")]
   public static ByteString ToByteString(this ReadOnlySequence<byte> sequence) => ByteString.CreateImmutable(sequence.ToArray());
 
   [Obsolete("use Smdn.Buffers.ReadOnlySequenceExtensions.SequenceEqual instead")]
```

</div>
</details>


