### PR TITLE
Release main/Smdn.Fundamental.Encoding-3.0.1

### DIFF
--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-net45.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.0 (net45))
+// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.1)
 //   Name: Smdn.Fundamental.Encoding
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (net45)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+403df09df7ef4576307947fac83e89eb7693a163
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 

--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard1.6.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.0 (netstandard1.6))
+// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.1)
 //   Name: Smdn.Fundamental.Encoding
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (netstandard1.6)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+403df09df7ef4576307947fac83e89eb7693a163
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 

--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.0 (netstandard2.1))
+// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.1)
 //   Name: Smdn.Fundamental.Encoding
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (netstandard2.1)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+403df09df7ef4576307947fac83e89eb7693a163
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #21](https://github.com/smdn/Smdn.Fundamentals/actions/runs/1872052569).

# Release target
## Release target info
- package_target_tag: `new-release/main/Smdn.Fundamental.Encoding-3.0.1`
- package_id: `Smdn.Fundamental.Encoding`
- package_id_with_version: `Smdn.Fundamental.Encoding-3.0.1`
- package_version: `3.0.1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.Encoding-3.0.1-1645364394`
- release_tag: `releases/Smdn.Fundamental.Encoding-3.0.1`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- artifact_name_nupkg: `Smdn.Fundamental.Encoding.3.0.1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

## .nuspec
```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.Encoding</id>
    <version>3.0.1</version>
    <title>Smdn.Fundamental.Encoding</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.Encoding.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.Encoding.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp encoding extensions</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="403df09df7ef4576307947fac83e89eb7693a163" />
    <dependencies>
      <group targetFramework=".NETFramework4.5" />
      <group targetFramework=".NETStandard1.6">
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Runtime.Serialization.Formatters" version="4.3.0" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.1" />
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/net45/Smdn.Fundamental.Encoding.dll" target="lib/net45/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/netstandard1.6/Smdn.Fundamental.Encoding.dll" target="lib/netstandard1.6/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/netstandard2.1/Smdn.Fundamental.Encoding.dll" target="lib/netstandard2.1/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/.nuget/packages/smdn.msbuild.projectassets.common/1.1.0/project/images/package-icon.png" target="Smdn.Fundamental.Encoding.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

<!-- RELEASE NOTE -->
# Packages
- NuGet [Smdn.Fundamental.Encoding version 3.0.1](https://www.nuget.org/packages/Smdn.Fundamental.Encoding/3.0.1)

# Changes in this release
## Change log
- 2022-02-20 [update assembly version](https://github.com/smdn/Smdn.Fundamentals/commit/403df09df7ef4576307947fac83e89eb7693a163)
- 2022-02-07 [use .NET SDK API symbols instead](https://github.com/smdn/Smdn.Fundamentals/commit/1afd43b08232077d89a97e3efa3ba553ac22d86e)
- 2022-02-05 [use StringBuilder.Append(ReadOnlySpan<char>) instead](https://github.com/smdn/Smdn.Fundamentals/commit/26fdd2baea2bbd14bbb3e1037d220a1583c5569f)
- 2022-02-04 [fix warning CA1305; use string interpolation instead](https://github.com/smdn/Smdn.Fundamentals/commit/44015ee3b3691ba812ac65db02801b03b09de77f)
- 2022-01-02 [define PackageTags](https://github.com/smdn/Smdn.Fundamentals/commit/81012f2f141eeeb5a771c348155efde8b13addd7)
- 2022-01-02 [refactor assembly attributes and package properties](https://github.com/smdn/Smdn.Fundamentals/commit/fb53ac2436caadd4dc156bb9e928250d5834e793)
- 2021-12-12 [enable package validation and define PackageValidationBaselineVersion](https://github.com/smdn/Smdn.Fundamentals/commit/316ff1d9e5f75a398d7aced03d63f5a7da5fa5e8)
- 2021-12-11 [use file-scoped namespace declaration](https://github.com/smdn/Smdn.Fundamentals/commit/2542ecae5e70a3d2daf638dade18bddb16543605)
- 2021-12-11 [modernize codes](https://github.com/smdn/Smdn.Fundamentals/commit/05815a4c350c795b1d5344173f7da6e63dd2051b)
- 2021-12-10 [fix indent](https://github.com/smdn/Smdn.Fundamentals/commit/0e9fd9db0638cfff834c6457761f41746427ebfe)
- 2021-12-10 [follow the code analyzer rules](https://github.com/smdn/Smdn.Fundamentals/commit/2033370f1103f89f1e443ebe00d22356ac049cbb)
- 2021-12-05 [modify to follow the code style rules](https://github.com/smdn/Smdn.Fundamentals/commit/a562029eb18ea239a2b10c12d1939ec1f8fdae18)

## API diff
<details>
<summary>API diff in this release</summary>
<div>

```diff
diff --git a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-net45.apilist.cs b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-net45.apilist.cs
index 9d699207..16090b71 100644
--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-net45.apilist.cs
@@ -1,40 +1,40 @@
-// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.0 (net45))
+// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.1)
 //   Name: Smdn.Fundamental.Encoding
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (net45)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+403df09df7ef4576307947fac83e89eb7693a163
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 
 using System;
 using System.Runtime.Serialization;
 using System.Text;
 using Smdn.Text.Encodings;
 
 namespace Smdn.Text.Encodings {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public delegate Encoding EncodingSelectionCallback(string name);
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [Serializable]
   public class EncodingNotSupportedException : NotSupportedException {
     protected EncodingNotSupportedException(SerializationInfo info, StreamingContext context) {}
     public EncodingNotSupportedException() {}
     public EncodingNotSupportedException(string encodingName) {}
     public EncodingNotSupportedException(string encodingName, Exception innerException) {}
     public EncodingNotSupportedException(string encodingName, string message) {}
     public EncodingNotSupportedException(string encodingName, string message, Exception innerException) {}
 
     public string EncodingName { get; }
 
     public override void GetObjectData(SerializationInfo info, StreamingContext context) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class EncodingUtils {
     public static Encoding GetEncoding(string name) {}
     public static Encoding GetEncoding(string name, EncodingSelectionCallback selectFallbackEncoding) {}
     public static Encoding GetEncodingThrowException(string name) {}
     public static Encoding GetEncodingThrowException(string name, EncodingSelectionCallback selectFallbackEncoding) {}
   }
 }
 
diff --git a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard1.6.apilist.cs b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard1.6.apilist.cs
index afb0e91c..1613b7bf 100644
--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard1.6.apilist.cs
@@ -1,36 +1,36 @@
-// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.0 (netstandard1.6))
+// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.1)
 //   Name: Smdn.Fundamental.Encoding
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (netstandard1.6)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+403df09df7ef4576307947fac83e89eb7693a163
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 
 using System;
 using System.Text;
 using Smdn.Text.Encodings;
 
 namespace Smdn.Text.Encodings {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public delegate Encoding EncodingSelectionCallback(string name);
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [Serializable]
   public class EncodingNotSupportedException : NotSupportedException {
     public EncodingNotSupportedException() {}
     public EncodingNotSupportedException(string encodingName) {}
     public EncodingNotSupportedException(string encodingName, Exception innerException) {}
     public EncodingNotSupportedException(string encodingName, string message) {}
     public EncodingNotSupportedException(string encodingName, string message, Exception innerException) {}
 
     public string EncodingName { get; }
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class EncodingUtils {
     public static Encoding GetEncoding(string name) {}
     public static Encoding GetEncoding(string name, EncodingSelectionCallback selectFallbackEncoding) {}
     public static Encoding GetEncodingThrowException(string name) {}
     public static Encoding GetEncodingThrowException(string name, EncodingSelectionCallback selectFallbackEncoding) {}
   }
 }
 
diff --git a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.1.apilist.cs b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.1.apilist.cs
index d1e4d1f1..271cf372 100644
--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.1.apilist.cs
@@ -1,40 +1,40 @@
-// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.0 (netstandard2.1))
+// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.1)
 //   Name: Smdn.Fundamental.Encoding
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (netstandard2.1)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+403df09df7ef4576307947fac83e89eb7693a163
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
 using System;
 using System.Runtime.Serialization;
 using System.Text;
 using Smdn.Text.Encodings;
 
 namespace Smdn.Text.Encodings {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public delegate Encoding EncodingSelectionCallback(string name);
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [Serializable]
   public class EncodingNotSupportedException : NotSupportedException {
     protected EncodingNotSupportedException(SerializationInfo info, StreamingContext context) {}
     public EncodingNotSupportedException() {}
     public EncodingNotSupportedException(string encodingName) {}
     public EncodingNotSupportedException(string encodingName, Exception innerException) {}
     public EncodingNotSupportedException(string encodingName, string message) {}
     public EncodingNotSupportedException(string encodingName, string message, Exception innerException) {}
 
     public string EncodingName { get; }
 
     public override void GetObjectData(SerializationInfo info, StreamingContext context) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class EncodingUtils {
     public static Encoding GetEncoding(string name) {}
     public static Encoding GetEncoding(string name, EncodingSelectionCallback selectFallbackEncoding) {}
     public static Encoding GetEncodingThrowException(string name) {}
     public static Encoding GetEncodingThrowException(string name, EncodingSelectionCallback selectFallbackEncoding) {}
   }
 }
 
```

</div>
</details>

## Changes
[Compare changes](https://github.com/smdn/Smdn.Fundamentals/compare/releases/Smdn.Fundamental.Encoding-3.0.0..releases/Smdn.Fundamental.Encoding-3.0.1)

<details>
<summary>Changes in this release</summary>
<div>

```diff
diff --git a/src/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding.csproj b/src/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding.csproj
index 7a20c33b..e52abd36 100644
--- a/src/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding.csproj
+++ b/src/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding.csproj
@@ -5,15 +5,17 @@ SPDX-License-Identifier: MIT
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.1;netstandard1.6</TargetFrameworks>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
+    <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
-  <PropertyGroup Label="metadata">
+  <PropertyGroup Label="assembly attributes">
     <CopyrightYear>2021</CopyrightYear>
+  </PropertyGroup>
 
-    <!-- NuGet -->
-    <!--<PackageTags></PackageTags>-->
+  <PropertyGroup Label="package properties">
+    <PackageTags>encoding;extensions</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
diff --git a/src/Smdn.Fundamental.Encoding/Smdn.Text.Encodings/EncodingNotSupportedException.cs b/src/Smdn.Fundamental.Encoding/Smdn.Text.Encodings/EncodingNotSupportedException.cs
index fd4140e9..f7c1cb89 100644
--- a/src/Smdn.Fundamental.Encoding/Smdn.Text.Encodings/EncodingNotSupportedException.cs
+++ b/src/Smdn.Fundamental.Encoding/Smdn.Text.Encodings/EncodingNotSupportedException.cs
@@ -3,67 +3,72 @@
 using System;
 using System.Runtime.Serialization;
 
-namespace Smdn.Text.Encodings {
-  [System.Runtime.CompilerServices.TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
-  [Serializable]
-  public class EncodingNotSupportedException : NotSupportedException {
-    /*
-     * XXX: code page not supported
-    public int CodePage {
-      get; private set;
-    }
-    */
+namespace Smdn.Text.Encodings;
 
-    public string EncodingName {
-      get; private set;
-    }
+[System.Runtime.CompilerServices.TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
+[Serializable]
+public class EncodingNotSupportedException : NotSupportedException {
+  /*
+   * XXX: code page not supported
+  public int CodePage {
+    get; private set;
+  }
+  */
+
+  public string EncodingName {
+    get; private set;
+  }
 
-    public EncodingNotSupportedException()
-      : this(null,
-             "encoding is not supported by runtime",
-             null)
-    {
-    }
+  public EncodingNotSupportedException()
+    : this(
+      null,
+      "encoding is not supported by runtime",
+      null
+    )
+  {
+  }
 
-    public EncodingNotSupportedException(string encodingName)
-      : this(encodingName,
-             string.Format("encoding '{0}' is not supported by runtime", encodingName),
-             null)
-    {
-    }
+  public EncodingNotSupportedException(string encodingName)
+    : this(
+      encodingName,
+      $"encoding '{encodingName}' is not supported by runtime",
+      null
+    )
+  {
+  }
 
-    public EncodingNotSupportedException(string encodingName, Exception innerException)
-      : this(encodingName,
-             string.Format("encoding '{0}' is not supported by runtime", encodingName),
-             innerException)
-    {
-    }
+  public EncodingNotSupportedException(string encodingName, Exception innerException)
+    : this(
+      encodingName,
+      $"encoding '{encodingName}' is not supported by runtime",
+      innerException
+    )
+  {
+  }
 
-    public EncodingNotSupportedException(string encodingName, string message)
-      : this(encodingName, message, null)
-    {
-    }
+  public EncodingNotSupportedException(string encodingName, string message)
+    : this(encodingName, message, null)
+  {
+  }
 
-    public EncodingNotSupportedException(string encodingName, string message, Exception innerException)
-      : base(message, innerException)
-    {
-      EncodingName = encodingName;
-    }
+  public EncodingNotSupportedException(string encodingName, string message, Exception innerException)
+    : base(message, innerException)
+  {
+    EncodingName = encodingName;
+  }
 
 #if SYSTEM_EXCEPTION_CTOR_SERIALIZATIONINFO
-    protected EncodingNotSupportedException(SerializationInfo info, StreamingContext context)
-      : base(info, context)
-    {
-      EncodingName = info.GetString("EncodingName");
-    }
+  protected EncodingNotSupportedException(SerializationInfo info, StreamingContext context)
+    : base(info, context)
+  {
+    EncodingName = info.GetString("EncodingName");
+  }
 
-    public override void GetObjectData(SerializationInfo info, StreamingContext context)
-    {
-      base.GetObjectData(info, context);
+  public override void GetObjectData(SerializationInfo info, StreamingContext context)
+  {
+    base.GetObjectData(info, context);
 
-      info.AddValue("EncodingName", EncodingName);
-    }
-#endif
+    info.AddValue("EncodingName", EncodingName);
   }
+#endif
 }
-
diff --git a/src/Smdn.Fundamental.Encoding/Smdn.Text.Encodings/EncodingSelectionCallback.cs b/src/Smdn.Fundamental.Encoding/Smdn.Text.Encodings/EncodingSelectionCallback.cs
index 2e7baa86..ac5c8ea4 100644
--- a/src/Smdn.Fundamental.Encoding/Smdn.Text.Encodings/EncodingSelectionCallback.cs
+++ b/src/Smdn.Fundamental.Encoding/Smdn.Text.Encodings/EncodingSelectionCallback.cs
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: 2010 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
-using System;
 using System.Text;
 
-namespace Smdn.Text.Encodings {
-  [System.Runtime.CompilerServices.TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
-  public delegate Encoding EncodingSelectionCallback(string name);
-}
+namespace Smdn.Text.Encodings;
+
+[System.Runtime.CompilerServices.TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
+public delegate Encoding EncodingSelectionCallback(string name);
diff --git a/src/Smdn.Fundamental.Encoding/Smdn.Text.Encodings/EncodingUtils.cs b/src/Smdn.Fundamental.Encoding/Smdn.Text.Encodings/EncodingUtils.cs
index a8e993ed..0815ac82 100644
--- a/src/Smdn.Fundamental.Encoding/Smdn.Text.Encodings/EncodingUtils.cs
+++ b/src/Smdn.Fundamental.Encoding/Smdn.Text.Encodings/EncodingUtils.cs
@@ -4,96 +4,97 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Smdn.Text.Encodings {
-  [System.Runtime.CompilerServices.TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
-  public static class EncodingUtils {
-    public static Encoding GetEncoding(string name)
-    {
-      return GetEncoding(name, null);
-    }
+namespace Smdn.Text.Encodings;
 
-    private static readonly char[] whiteSpaceChars = new[] {'-', '_', ' '};
+[System.Runtime.CompilerServices.TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
+public static class EncodingUtils {
+  public static Encoding GetEncoding(string name)
+    => GetEncoding(name, null);
 
-    private static string NormalizeEncodingName(string name)
-    {
-      var normalizedName = name.Trim(); // remove leading and trailing whitespaces (\x20, \n, \t, etc.)
-      var normalizedNameBuffer = new StringBuilder(normalizedName.Length);
-      var lastIndex = 0;
+  private static readonly char[] whiteSpaceChars = new[] { '-', '_', ' ' };
 
-      for (; ; ) {
-        var index = normalizedName.IndexOfAny(whiteSpaceChars, lastIndex);
+  private static string NormalizeEncodingName(string name)
+  {
+    var normalizedName = name.Trim(); // remove leading and trailing whitespaces (\x20, \n, \t, etc.)
+    var normalizedNameBuffer = new StringBuilder(normalizedName.Length);
+    var lastIndex = 0;
 
-        if (index < 0) {
-          normalizedNameBuffer.Append(normalizedName.Substring(lastIndex));
+    for (; ; ) {
+      var index = normalizedName.IndexOfAny(whiteSpaceChars, lastIndex);
 
-          if (normalizedName.Length == normalizedNameBuffer.Length)
-            return normalizedName;
-          else
-            return normalizedNameBuffer.ToString();
-        }
-        else {
-          normalizedNameBuffer.Append(normalizedName.Substring(lastIndex, index - lastIndex));
+      if (index < 0) {
+#if SYSTEM_TEXT_STRINGBUILDER_APPEND_READONLYSPAN_OF_CHAR
+        normalizedNameBuffer.Append(normalizedName.AsSpan(lastIndex));
+#else
+        normalizedNameBuffer.Append(normalizedName.Substring(lastIndex));
+#endif
 
-          lastIndex = index + 1;
-        }
+        if (normalizedName.Length == normalizedNameBuffer.Length)
+          return normalizedName;
+        else
+          return normalizedNameBuffer.ToString();
       }
-    }
-
-    public static Encoding GetEncoding(string name,
-                                       EncodingSelectionCallback selectFallbackEncoding)
-    {
-      if (name == null)
-        throw new ArgumentNullException(nameof(name));
+      else {
+#if SYSTEM_TEXT_STRINGBUILDER_APPEND_READONLYSPAN_OF_CHAR
+        normalizedNameBuffer.Append(normalizedName.AsSpan(lastIndex, index - lastIndex));
+#else
+        normalizedNameBuffer.Append(normalizedName.Substring(lastIndex, index - lastIndex));
+#endif
 
-      if (!encodingCollationTable.TryGetValue(NormalizeEncodingName(name), out var encodingName))
-        encodingName = name;
-
-      try {
-        return Encoding.GetEncoding(encodingName);
-      }
-      catch (ArgumentException) {
-        // illegal or unsupported
-        if (selectFallbackEncoding == null)
-          return null;
-        else
-          return selectFallbackEncoding(name); // trimmed name
+        lastIndex = index + 1;
       }
     }
+  }
 
-    public static Encoding GetEncodingThrowException(string name)
-    {
-      return GetEncodingThrowException(name, null);
-    }
+  public static Encoding GetEncoding(
+    string name,
+    EncodingSelectionCallback selectFallbackEncoding
+  )
+  {
+    if (name == null)
+      throw new ArgumentNullException(nameof(name));
 
-    public static Encoding GetEncodingThrowException(string name,
-                                                     EncodingSelectionCallback selectFallbackEncoding)
-    {
-      var encoding = GetEncoding(name, selectFallbackEncoding);
+    if (!encodingCollationTable.TryGetValue(NormalizeEncodingName(name), out var encodingName))
+      encodingName = name;
 
-      if (encoding == null)
-        throw new EncodingNotSupportedException(name);
+    try {
+      return Encoding.GetEncoding(encodingName);
+    }
+    catch (ArgumentException) {
+      // illegal or unsupported
+      if (selectFallbackEncoding == null)
+        return null;
       else
-        return encoding;
+        return selectFallbackEncoding(name); // trimmed name
     }
+  }
 
-    private static readonly Dictionary<string, string> encodingCollationTable
-      = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+  public static Encoding GetEncodingThrowException(string name)
+    => GetEncodingThrowException(name, null);
+
+  public static Encoding GetEncodingThrowException(
+    string name,
+    EncodingSelectionCallback selectFallbackEncoding
+  )
+    => GetEncoding(name, selectFallbackEncoding) ?? throw new EncodingNotSupportedException(name);
+
+  private static readonly Dictionary<string, string> encodingCollationTable
+    = new(StringComparer.OrdinalIgnoreCase) {
       /* UTF-16 */
-      {"utf16",       "utf-16"},
+      { "utf16",       "utf-16" },
       /* UTF-8 */
-      {"utf8",        "utf-8"},
+      { "utf8",        "utf-8" },
       /* Shift_JIS */
-      {"shiftjis",    "shift_jis"},     // shift_jis
-      {"xsjis",       "shift_jis"},     // x-sjis
+      { "shiftjis",    "shift_jis" },     // shift_jis
+      { "xsjis",       "shift_jis" },     // x-sjis
       /* EUC-JP */
-      {"eucjp",       "euc-jp"},        // euc-jp
-      {"xeucjp",      "euc-jp"},        // x-euc-jp
+      { "eucjp",       "euc-jp" },        // euc-jp
+      { "xeucjp",      "euc-jp" },        // x-euc-jp
       /* ISO-2022-JP */
-      {"iso2022jp",   "iso-2022-jp"},   // iso-2022-jp
+      { "iso2022jp",   "iso-2022-jp" },   // iso-2022-jp
 
       // TODO
       // {"utf16be",     "utf-16"},
       // {"utf16le",     "utf-16"},
     };
-  }
 }
```

</div>
</details>


