### PR TITLE
Release main/Smdn.Fundamental.Stream.LineOriented-3.0.2

### DIFF
--- a/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-net45.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.1 (net45))
+// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.2)
 //   Name: Smdn.Fundamental.Stream.LineOriented
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (net45)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+f6313286e6c89f255a4e55ad199841306da18ec2
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 

--- a/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-net5.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-net5.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.1 (net5.0))
+// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.2)
 //   Name: Smdn.Fundamental.Stream.LineOriented
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (net5.0)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+f6313286e6c89f255a4e55ad199841306da18ec2
 //   TargetFramework: .NETCoreApp,Version=v5.0
 //   Configuration: Release
 
@@ -50,6 +50,7 @@ namespace Smdn.IO.Streams.LineOriented {
     public override int Read(byte[] buffer, int offset, int count) {}
     public Task<long> ReadAsync(Stream targetStream, long length, CancellationToken cancellationToken = default) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) {}
     public override int ReadByte() {}
     public LineOrientedStream.Line? ReadLine() {}
     public byte[] ReadLine(bool keepEOL) {}
@@ -58,6 +59,7 @@ namespace Smdn.IO.Streams.LineOriented {
     public override void SetLength(long @value) {}
     public override void Write(byte[] buffer, int offset, int count) {}
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]

--- a/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-netstandard1.6.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.1 (netstandard1.6))
+// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.2)
 //   Name: Smdn.Fundamental.Stream.LineOriented
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (netstandard1.6)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+f6313286e6c89f255a4e55ad199841306da18ec2
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 

--- a/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.1 (netstandard2.1))
+// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.2)
 //   Name: Smdn.Fundamental.Stream.LineOriented
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (netstandard2.1)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+f6313286e6c89f255a4e55ad199841306da18ec2
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
@@ -50,6 +50,7 @@ namespace Smdn.IO.Streams.LineOriented {
     public override int Read(byte[] buffer, int offset, int count) {}
     public Task<long> ReadAsync(Stream targetStream, long length, CancellationToken cancellationToken = default) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) {}
     public override int ReadByte() {}
     public LineOrientedStream.Line? ReadLine() {}
     public byte[] ReadLine(bool keepEOL) {}
@@ -58,6 +59,7 @@ namespace Smdn.IO.Streams.LineOriented {
     public override void SetLength(long @value) {}
     public override void Write(byte[] buffer, int offset, int count) {}
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #36](https://github.com/smdn/Smdn.Fundamentals/actions/runs/1872204454).

# Release target
## Release target info
- package_target_tag: `new-release/main/Smdn.Fundamental.Stream.LineOriented-3.0.2`
- package_id: `Smdn.Fundamental.Stream.LineOriented`
- package_id_with_version: `Smdn.Fundamental.Stream.LineOriented-3.0.2`
- package_version: `3.0.2`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.Stream.LineOriented-3.0.2-1645368438`
- release_tag: `releases/Smdn.Fundamental.Stream.LineOriented-3.0.2`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- artifact_name_nupkg: `Smdn.Fundamental.Stream.LineOriented.3.0.2.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

## .nuspec
```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.Stream.LineOriented</id>
    <version>3.0.2</version>
    <title>Smdn.Fundamental.Stream.LineOriented</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.Stream.LineOriented.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.Stream.LineOriented.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp stream line-oriented newline</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="f6313286e6c89f255a4e55ad199841306da18ec2" />
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
      <group targetFramework="net5.0">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.1">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.LineOriented/bin/Release/net45/Smdn.Fundamental.Stream.LineOriented.dll" target="lib/net45/Smdn.Fundamental.Stream.LineOriented.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.LineOriented/bin/Release/net5.0/Smdn.Fundamental.Stream.LineOriented.dll" target="lib/net5.0/Smdn.Fundamental.Stream.LineOriented.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.LineOriented/bin/Release/netstandard1.6/Smdn.Fundamental.Stream.LineOriented.dll" target="lib/netstandard1.6/Smdn.Fundamental.Stream.LineOriented.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.LineOriented/bin/Release/netstandard2.1/Smdn.Fundamental.Stream.LineOriented.dll" target="lib/netstandard2.1/Smdn.Fundamental.Stream.LineOriented.dll" />
    <file src="/home/runner/.nuget/packages/smdn.msbuild.projectassets.common/1.1.0/project/images/package-icon.png" target="Smdn.Fundamental.Stream.LineOriented.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.LineOriented/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

<!-- RELEASE NOTE -->
# Packages
- NuGet [Smdn.Fundamental.Stream.LineOriented version 3.0.2](https://www.nuget.org/packages/Smdn.Fundamental.Stream.LineOriented/3.0.2)

# Changes in this release
## Change log
- 2022-02-20 [update assembly version](https://github.com/smdn/Smdn.Fundamentals/commit/f6313286e6c89f255a4e55ad199841306da18ec2)
- 2022-02-07 [use .NET SDK API symbols instead](https://github.com/smdn/Smdn.Fundamentals/commit/1afd43b08232077d89a97e3efa3ba553ac22d86e)
- 2022-02-05 [add comment](https://github.com/smdn/Smdn.Fundamentals/commit/1cca7d7ba3fd7d634e40835672ce44bdcb8ddb56)
- 2022-02-04 [override Stream.ReadAsync(Memory, CancellationToken)](https://github.com/smdn/Smdn.Fundamentals/commit/93e886043f4b12b8f17467260e99d6c96cb2df23)
- 2022-02-04 [override Stream.WriteAsync(ReadOnlyMemory, CancellationToken)](https://github.com/smdn/Smdn.Fundamentals/commit/0b6a41d9ee539600e51182b24ad51444de5553e4)
- 2022-01-02 [define PackageTags](https://github.com/smdn/Smdn.Fundamentals/commit/81012f2f141eeeb5a771c348155efde8b13addd7)
- 2022-01-02 [refactor assembly attributes and package properties](https://github.com/smdn/Smdn.Fundamentals/commit/fb53ac2436caadd4dc156bb9e928250d5834e793)

## API diff
<details>
<summary>API diff in this release</summary>
<div>

```diff
diff --git a/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-net45.apilist.cs b/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-net45.apilist.cs
index e7f1d225..c60ff205 100644
--- a/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-net45.apilist.cs
@@ -1,74 +1,74 @@
-// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.1 (net45))
+// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.2)
 //   Name: Smdn.Fundamental.Stream.LineOriented
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (net45)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+f6313286e6c89f255a4e55ad199841306da18ec2
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 
 using System;
 using System.Buffers;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.IO.Streams.LineOriented;
 
 namespace Smdn.IO.Streams.LineOriented {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class LineOrientedStream : Stream {
     public readonly struct Line {
       public Line(ReadOnlySequence<byte> sequenceWithNewLine, SequencePosition positionOfNewLine) {}
 
       public bool IsEmpty { get; }
       public ReadOnlySequence<byte> NewLine { get; }
       public SequencePosition PositionOfNewLine { get; }
       public ReadOnlySequence<byte> Sequence { get; }
       public ReadOnlySequence<byte> SequenceWithNewLine { get; }
     }
 
     protected const int DefaultBufferSize = 1024;
     protected const bool DefaultLeaveStreamOpen = false;
     protected const int MinimumBufferSize = 8;
 
     public LineOrientedStream(Stream stream, ReadOnlySpan<byte> newLine, int bufferSize = 1024, bool leaveStreamOpen = false) {}
 
     public int BufferSize { get; }
     public override bool CanRead { get; }
     public override bool CanSeek { get; }
     public override bool CanTimeout { get; }
     public override bool CanWrite { get; }
     public virtual Stream InnerStream { get; }
     public bool IsStrictNewLine { get; }
     public override long Length { get; }
     public ReadOnlySpan<byte> NewLine { get; }
     public override long Position { get; set; }
 
     public override Task CopyToAsync(Stream destination, int bufferSize = 0, CancellationToken cancellationToken = default) {}
     protected override void Dispose(bool disposing) {}
     public override void Flush() {}
     public override Task FlushAsync(CancellationToken cancellationToken) {}
     public long Read(Stream targetStream, long length) {}
     public override int Read(byte[] buffer, int offset, int count) {}
     public Task<long> ReadAsync(Stream targetStream, long length, CancellationToken cancellationToken = default) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
     public override int ReadByte() {}
     public LineOrientedStream.Line? ReadLine() {}
     public byte[] ReadLine(bool keepEOL) {}
     public Task<LineOrientedStream.Line?> ReadLineAsync(CancellationToken cancellationToken = default) {}
     public override long Seek(long offset, SeekOrigin origin) {}
     public override void SetLength(long @value) {}
     public override void Write(byte[] buffer, int offset, int count) {}
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class LooseLineOrientedStream : LineOrientedStream {
     public LooseLineOrientedStream(Stream stream, int bufferSize = 1024, bool leaveStreamOpen = false) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class StrictLineOrientedStream : LineOrientedStream {
     public StrictLineOrientedStream(Stream stream, ReadOnlySpan<byte> newLine, int bufferSize = 1024, bool leaveStreamOpen = false) {}
     public StrictLineOrientedStream(Stream stream, int bufferSize = 1024, bool leaveStreamOpen = false) {}
   }
 }
 
diff --git a/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-net5.0.apilist.cs b/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-net5.0.apilist.cs
index 9aa9cbab..73e88c32 100644
--- a/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-net5.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-net5.0.apilist.cs
@@ -1,74 +1,76 @@
-// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.1 (net5.0))
+// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.2)
 //   Name: Smdn.Fundamental.Stream.LineOriented
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (net5.0)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+f6313286e6c89f255a4e55ad199841306da18ec2
 //   TargetFramework: .NETCoreApp,Version=v5.0
 //   Configuration: Release
 
 using System;
 using System.Buffers;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.IO.Streams.LineOriented;
 
 namespace Smdn.IO.Streams.LineOriented {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class LineOrientedStream : Stream {
     public readonly struct Line {
       public Line(ReadOnlySequence<byte> sequenceWithNewLine, SequencePosition positionOfNewLine) {}
 
       public bool IsEmpty { get; }
       public ReadOnlySequence<byte> NewLine { get; }
       public SequencePosition PositionOfNewLine { get; }
       public ReadOnlySequence<byte> Sequence { get; }
       public ReadOnlySequence<byte> SequenceWithNewLine { get; }
     }
 
     protected const int DefaultBufferSize = 1024;
     protected const bool DefaultLeaveStreamOpen = false;
     protected const int MinimumBufferSize = 8;
 
     public LineOrientedStream(Stream stream, ReadOnlySpan<byte> newLine, int bufferSize = 1024, bool leaveStreamOpen = false) {}
 
     public int BufferSize { get; }
     public override bool CanRead { get; }
     public override bool CanSeek { get; }
     public override bool CanTimeout { get; }
     public override bool CanWrite { get; }
     public virtual Stream InnerStream { get; }
     public bool IsStrictNewLine { get; }
     public override long Length { get; }
     public ReadOnlySpan<byte> NewLine { get; }
     public override long Position { get; set; }
 
     public override Task CopyToAsync(Stream destination, int bufferSize = 0, CancellationToken cancellationToken = default) {}
     protected override void Dispose(bool disposing) {}
     public override void Flush() {}
     public override Task FlushAsync(CancellationToken cancellationToken) {}
     public long Read(Stream targetStream, long length) {}
     public override int Read(byte[] buffer, int offset, int count) {}
     public Task<long> ReadAsync(Stream targetStream, long length, CancellationToken cancellationToken = default) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) {}
     public override int ReadByte() {}
     public LineOrientedStream.Line? ReadLine() {}
     public byte[] ReadLine(bool keepEOL) {}
     public Task<LineOrientedStream.Line?> ReadLineAsync(CancellationToken cancellationToken = default) {}
     public override long Seek(long offset, SeekOrigin origin) {}
     public override void SetLength(long @value) {}
     public override void Write(byte[] buffer, int offset, int count) {}
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class LooseLineOrientedStream : LineOrientedStream {
     public LooseLineOrientedStream(Stream stream, int bufferSize = 1024, bool leaveStreamOpen = false) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class StrictLineOrientedStream : LineOrientedStream {
     public StrictLineOrientedStream(Stream stream, ReadOnlySpan<byte> newLine, int bufferSize = 1024, bool leaveStreamOpen = false) {}
     public StrictLineOrientedStream(Stream stream, int bufferSize = 1024, bool leaveStreamOpen = false) {}
   }
 }
 
diff --git a/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-netstandard1.6.apilist.cs b/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-netstandard1.6.apilist.cs
index b7c3c32a..37d0e3ac 100644
--- a/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-netstandard1.6.apilist.cs
@@ -1,74 +1,74 @@
-// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.1 (netstandard1.6))
+// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.2)
 //   Name: Smdn.Fundamental.Stream.LineOriented
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (netstandard1.6)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+f6313286e6c89f255a4e55ad199841306da18ec2
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 
 using System;
 using System.Buffers;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.IO.Streams.LineOriented;
 
 namespace Smdn.IO.Streams.LineOriented {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class LineOrientedStream : Stream {
     public readonly struct Line {
       public Line(ReadOnlySequence<byte> sequenceWithNewLine, SequencePosition positionOfNewLine) {}
 
       public bool IsEmpty { get; }
       public ReadOnlySequence<byte> NewLine { get; }
       public SequencePosition PositionOfNewLine { get; }
       public ReadOnlySequence<byte> Sequence { get; }
       public ReadOnlySequence<byte> SequenceWithNewLine { get; }
     }
 
     protected const int DefaultBufferSize = 1024;
     protected const bool DefaultLeaveStreamOpen = false;
     protected const int MinimumBufferSize = 8;
 
     public LineOrientedStream(Stream stream, ReadOnlySpan<byte> newLine, int bufferSize = 1024, bool leaveStreamOpen = false) {}
 
     public int BufferSize { get; }
     public override bool CanRead { get; }
     public override bool CanSeek { get; }
     public override bool CanTimeout { get; }
     public override bool CanWrite { get; }
     public virtual Stream InnerStream { get; }
     public bool IsStrictNewLine { get; }
     public override long Length { get; }
     public ReadOnlySpan<byte> NewLine { get; }
     public override long Position { get; set; }
 
     public override Task CopyToAsync(Stream destination, int bufferSize = 0, CancellationToken cancellationToken = default) {}
     protected override void Dispose(bool disposing) {}
     public override void Flush() {}
     public override Task FlushAsync(CancellationToken cancellationToken) {}
     public long Read(Stream targetStream, long length) {}
     public override int Read(byte[] buffer, int offset, int count) {}
     public Task<long> ReadAsync(Stream targetStream, long length, CancellationToken cancellationToken = default) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
     public override int ReadByte() {}
     public LineOrientedStream.Line? ReadLine() {}
     public byte[] ReadLine(bool keepEOL) {}
     public Task<LineOrientedStream.Line?> ReadLineAsync(CancellationToken cancellationToken = default) {}
     public override long Seek(long offset, SeekOrigin origin) {}
     public override void SetLength(long @value) {}
     public override void Write(byte[] buffer, int offset, int count) {}
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class LooseLineOrientedStream : LineOrientedStream {
     public LooseLineOrientedStream(Stream stream, int bufferSize = 1024, bool leaveStreamOpen = false) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class StrictLineOrientedStream : LineOrientedStream {
     public StrictLineOrientedStream(Stream stream, ReadOnlySpan<byte> newLine, int bufferSize = 1024, bool leaveStreamOpen = false) {}
     public StrictLineOrientedStream(Stream stream, int bufferSize = 1024, bool leaveStreamOpen = false) {}
   }
 }
 
diff --git a/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-netstandard2.1.apilist.cs b/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-netstandard2.1.apilist.cs
index c4f2b0f6..d719d00f 100644
--- a/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented-netstandard2.1.apilist.cs
@@ -1,74 +1,76 @@
-// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.1 (netstandard2.1))
+// Smdn.Fundamental.Stream.LineOriented.dll (Smdn.Fundamental.Stream.LineOriented-3.0.2)
 //   Name: Smdn.Fundamental.Stream.LineOriented
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (netstandard2.1)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+f6313286e6c89f255a4e55ad199841306da18ec2
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
 using System;
 using System.Buffers;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.IO.Streams.LineOriented;
 
 namespace Smdn.IO.Streams.LineOriented {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class LineOrientedStream : Stream {
     public readonly struct Line {
       public Line(ReadOnlySequence<byte> sequenceWithNewLine, SequencePosition positionOfNewLine) {}
 
       public bool IsEmpty { get; }
       public ReadOnlySequence<byte> NewLine { get; }
       public SequencePosition PositionOfNewLine { get; }
       public ReadOnlySequence<byte> Sequence { get; }
       public ReadOnlySequence<byte> SequenceWithNewLine { get; }
     }
 
     protected const int DefaultBufferSize = 1024;
     protected const bool DefaultLeaveStreamOpen = false;
     protected const int MinimumBufferSize = 8;
 
     public LineOrientedStream(Stream stream, ReadOnlySpan<byte> newLine, int bufferSize = 1024, bool leaveStreamOpen = false) {}
 
     public int BufferSize { get; }
     public override bool CanRead { get; }
     public override bool CanSeek { get; }
     public override bool CanTimeout { get; }
     public override bool CanWrite { get; }
     public virtual Stream InnerStream { get; }
     public bool IsStrictNewLine { get; }
     public override long Length { get; }
     public ReadOnlySpan<byte> NewLine { get; }
     public override long Position { get; set; }
 
     public override Task CopyToAsync(Stream destination, int bufferSize = 0, CancellationToken cancellationToken = default) {}
     protected override void Dispose(bool disposing) {}
     public override void Flush() {}
     public override Task FlushAsync(CancellationToken cancellationToken) {}
     public long Read(Stream targetStream, long length) {}
     public override int Read(byte[] buffer, int offset, int count) {}
     public Task<long> ReadAsync(Stream targetStream, long length, CancellationToken cancellationToken = default) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) {}
     public override int ReadByte() {}
     public LineOrientedStream.Line? ReadLine() {}
     public byte[] ReadLine(bool keepEOL) {}
     public Task<LineOrientedStream.Line?> ReadLineAsync(CancellationToken cancellationToken = default) {}
     public override long Seek(long offset, SeekOrigin origin) {}
     public override void SetLength(long @value) {}
     public override void Write(byte[] buffer, int offset, int count) {}
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class LooseLineOrientedStream : LineOrientedStream {
     public LooseLineOrientedStream(Stream stream, int bufferSize = 1024, bool leaveStreamOpen = false) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class StrictLineOrientedStream : LineOrientedStream {
     public StrictLineOrientedStream(Stream stream, ReadOnlySpan<byte> newLine, int bufferSize = 1024, bool leaveStreamOpen = false) {}
     public StrictLineOrientedStream(Stream stream, int bufferSize = 1024, bool leaveStreamOpen = false) {}
   }
 }
 
```

</div>
</details>

## Changes
[Compare changes](https://github.com/smdn/Smdn.Fundamentals/compare/releases/Smdn.Fundamental.Stream.LineOriented-3.0.1..releases/Smdn.Fundamental.Stream.LineOriented-3.0.2)

<details>
<summary>Changes in this release</summary>
<div>

```diff
diff --git a/src/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented.csproj b/src/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented.csproj
index e5b34b6c..57297bb0 100644
--- a/src/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented.csproj
+++ b/src/Smdn.Fundamental.Stream.LineOriented/Smdn.Fundamental.Stream.LineOriented.csproj
@@ -5,16 +5,17 @@ SPDX-License-Identifier: MIT
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net5.0;net45;netstandard2.1;netstandard1.6</TargetFrameworks>
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <VersionPrefix>3.0.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
-  <PropertyGroup Label="metadata">
+  <PropertyGroup Label="assembly attributes">
     <CopyrightYear>2021</CopyrightYear>
+  </PropertyGroup>
 
-    <!-- NuGet -->
-    <!--<PackageTags></PackageTags>-->
+  <PropertyGroup Label="package properties">
+    <PackageTags>stream;line-oriented;newline</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
diff --git a/src/Smdn.Fundamental.Stream.LineOriented/Smdn.IO.Streams.LineOriented/LineOrientedStream.cs b/src/Smdn.Fundamental.Stream.LineOriented/Smdn.IO.Streams.LineOriented/LineOrientedStream.cs
index 946006f2..c0e9266e 100644
--- a/src/Smdn.Fundamental.Stream.LineOriented/Smdn.IO.Streams.LineOriented/LineOrientedStream.cs
+++ b/src/Smdn.Fundamental.Stream.LineOriented/Smdn.IO.Streams.LineOriented/LineOrientedStream.cs
@@ -456,66 +456,116 @@ public class LineOrientedStream : Stream {
     if (count == 0L)
       return Task.FromResult(0); // do nothing
 
+    return ReadAsyncCore(
+      destination: buffer.AsMemory(offset, count),
+      cancellationToken: cancellationToken
+#if SYSTEM_THREADING_TASKS_VALUETASK
+    ).AsTask();
+#else
+    );
+#endif
+  }
+
+#if SYSTEM_IO_STREAM_READASYNC_MEMORY_OF_BYTE
+  public override ValueTask<int> ReadAsync(
+    Memory<byte> buffer,
+    CancellationToken cancellationToken = default
+  )
+  {
+    CheckDisposed();
+
+    if (cancellationToken.IsCancellationRequested)
+#if SYSTEM_THREADING_TASKS_VALUETASK_FROMCANCELED
+      return ValueTask.FromCanceled<int>(cancellationToken);
+#else
+#if SYSTEM_THREADING_TASKS_TASK_FROMCANCELED
+      return new(Task.FromCanceled<int>(cancellationToken));
+#else
+      return new(new Task<int>(() => default, cancellationToken));
+#endif
+#endif
+
+    if (buffer.IsEmpty)
+      return new(0); // do nothing
+
     return ReadAsyncCore(
       destination: buffer,
-      offset: offset,
-      count: count,
       cancellationToken: cancellationToken
     );
   }
+#endif
 
-  private async Task<int> ReadAsyncCore(
-    byte[] destination,
-    int offset,
-    int count,
+  private async
+#if SYSTEM_THREADING_TASKS_VALUETASK
+  ValueTask<int>
+#else
+  Task<int>
+#endif
+  ReadAsyncCore(
+    Memory<byte> destination,
     CancellationToken cancellationToken
   )
   {
-    if (count <= bufRemain) {
-      Buffer.BlockCopy(buffer, bufOffset, destination, offset, count);
-      bufOffset += count;
-      bufRemain -= count;
+    if (destination.Length <= bufRemain) {
+      buffer.AsSpan(bufOffset, destination.Length).CopyTo(destination.Span);
+      bufOffset += destination.Length;
+      bufRemain -= destination.Length;
 
-      return count;
+      return destination.Length;
     }
 
     var read = 0;
 
     if (bufRemain != 0) {
-      Buffer.BlockCopy(buffer, bufOffset, destination, offset, bufRemain);
+      buffer.AsSpan(bufOffset, bufRemain).CopyTo(destination.Span);
 
       read = bufRemain;
-      offset += bufRemain;
-      count -= bufRemain;
+
+      destination = destination.Slice(bufRemain);
 
       bufRemain = 0;
     }
 
     // read from base stream
     for (; ; ) {
-      if (count <= 0)
+      if (destination.IsEmpty)
         break;
 
-      var r =
 #if SYSTEM_IO_STREAM_READASYNC_MEMORY_OF_BYTE
-        await stream.ReadAsync(
-          destination.AsMemory(offset, count),
+      var r = await stream.ReadAsync(
+        destination,
+        cancellationToken
+      ).ConfigureAwait(false);
 #else
 #pragma warning disable CA1835
-        await stream.ReadAsync(
-          destination,
-          offset,
-          count,
-#pragma warning restore CA1835
-#endif
+      byte[] readBuffer = null;
+      int r = 0;
+
+      try {
+        readBuffer = ArrayPool<byte>.Shared.Rent(destination.Length);
+
+        r = await stream.ReadAsync(
+          readBuffer,
+          0,
+          destination.Length,
           cancellationToken
         ).ConfigureAwait(false);
+      }
+      finally {
+        if (readBuffer is not null) {
+          if (0 < r)
+            readBuffer.AsMemory(0, r).CopyTo(destination);
+
+          ArrayPool<byte>.Shared.Return(readBuffer);
+        }
+      }
+#pragma warning restore CA1835
+#endif
 
       if (r <= 0)
         break;
 
-      offset += r;
-      count -= r;
+      destination = destination.Slice(r);
       read += r;
     }
 
@@ -558,6 +608,15 @@ public class LineOrientedStream : Stream {
     return stream.WriteAsync(buffer, offset, count, cancellationToken);
   }
 
+#if SYSTEM_IO_STREAM_WRITEASYNC_READONLYMEMORY_OF_BYTE
+  public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+  {
+    CheckDisposed();
+
+    return stream.WriteAsync(buffer, cancellationToken);
+  }
+#endif
+
   public override Task CopyToAsync(
     Stream destination,
     int bufferSize = 0, // don't care
```

</div>
</details>


