### PR TITLE
Release main/Smdn.Fundamental.UInt24n-3.0.2

### DIFF
--- a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-net45.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.0.1 (net45))
+// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.0.2)
 //   Name: Smdn.Fundamental.UInt24n
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (net45)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+ba1968924b0078e56f5205dd0ae2468ee96e6071
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 
@@ -75,7 +75,11 @@ namespace Smdn {
     public static explicit operator short(UInt24 val) {}
     public static explicit operator uint(UInt24 val) {}
     public static explicit operator ushort(UInt24 val) {}
+    public static bool operator > (UInt24 x, UInt24 y) {}
+    public static bool operator >= (UInt24 x, UInt24 y) {}
     public static bool operator != (UInt24 x, UInt24 y) {}
+    public static bool operator < (UInt24 x, UInt24 y) {}
+    public static bool operator <= (UInt24 x, UInt24 y) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
@@ -150,7 +154,11 @@ namespace Smdn {
     public static explicit operator long(UInt48 val) {}
     public static explicit operator uint(UInt48 val) {}
     public static explicit operator ulong(UInt48 val) {}
+    public static bool operator > (UInt48 x, UInt48 y) {}
+    public static bool operator >= (UInt48 x, UInt48 y) {}
     public static bool operator != (UInt48 x, UInt48 y) {}
+    public static bool operator < (UInt48 x, UInt48 y) {}
+    public static bool operator <= (UInt48 x, UInt48 y) {}
   }
 }
 

--- a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard1.6.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.0.1 (netstandard1.6))
+// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.0.2)
 //   Name: Smdn.Fundamental.UInt24n
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (netstandard1.6)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+ba1968924b0078e56f5205dd0ae2468ee96e6071
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 
@@ -75,7 +75,11 @@ namespace Smdn {
     public static explicit operator short(UInt24 val) {}
     public static explicit operator uint(UInt24 val) {}
     public static explicit operator ushort(UInt24 val) {}
+    public static bool operator > (UInt24 x, UInt24 y) {}
+    public static bool operator >= (UInt24 x, UInt24 y) {}
     public static bool operator != (UInt24 x, UInt24 y) {}
+    public static bool operator < (UInt24 x, UInt24 y) {}
+    public static bool operator <= (UInt24 x, UInt24 y) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
@@ -150,7 +154,11 @@ namespace Smdn {
     public static explicit operator long(UInt48 val) {}
     public static explicit operator uint(UInt48 val) {}
     public static explicit operator ulong(UInt48 val) {}
+    public static bool operator > (UInt48 x, UInt48 y) {}
+    public static bool operator >= (UInt48 x, UInt48 y) {}
     public static bool operator != (UInt48 x, UInt48 y) {}
+    public static bool operator < (UInt48 x, UInt48 y) {}
+    public static bool operator <= (UInt48 x, UInt48 y) {}
   }
 }
 

--- a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.0.1 (netstandard2.1))
+// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.0.2)
 //   Name: Smdn.Fundamental.UInt24n
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (netstandard2.1)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+ba1968924b0078e56f5205dd0ae2468ee96e6071
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
@@ -75,7 +75,11 @@ namespace Smdn {
     public static explicit operator short(UInt24 val) {}
     public static explicit operator uint(UInt24 val) {}
     public static explicit operator ushort(UInt24 val) {}
+    public static bool operator > (UInt24 x, UInt24 y) {}
+    public static bool operator >= (UInt24 x, UInt24 y) {}
     public static bool operator != (UInt24 x, UInt24 y) {}
+    public static bool operator < (UInt24 x, UInt24 y) {}
+    public static bool operator <= (UInt24 x, UInt24 y) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
@@ -150,7 +154,11 @@ namespace Smdn {
     public static explicit operator long(UInt48 val) {}
     public static explicit operator uint(UInt48 val) {}
     public static explicit operator ulong(UInt48 val) {}
+    public static bool operator > (UInt48 x, UInt48 y) {}
+    public static bool operator >= (UInt48 x, UInt48 y) {}
     public static bool operator != (UInt48 x, UInt48 y) {}
+    public static bool operator < (UInt48 x, UInt48 y) {}
+    public static bool operator <= (UInt48 x, UInt48 y) {}
   }
 }
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #37](https://github.com/smdn/Smdn.Fundamentals/actions/runs/1872209030).

# Release target
## Release target info
- package_target_tag: `new-release/main/Smdn.Fundamental.UInt24n-3.0.2`
- package_id: `Smdn.Fundamental.UInt24n`
- package_id_with_version: `Smdn.Fundamental.UInt24n-3.0.2`
- package_version: `3.0.2`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.UInt24n-3.0.2-1645368574`
- release_tag: `releases/Smdn.Fundamental.UInt24n-3.0.2`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- artifact_name_nupkg: `Smdn.Fundamental.UInt24n.3.0.2.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

## .nuspec
```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.UInt24n</id>
    <version>3.0.2</version>
    <title>Smdn.Fundamental.UInt24n</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.UInt24n.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.UInt24n.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp uint24 uint48 24bit 48bit interger</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="ba1968924b0078e56f5205dd0ae2468ee96e6071" />
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.1">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/net45/Smdn.Fundamental.UInt24n.dll" target="lib/net45/Smdn.Fundamental.UInt24n.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/netstandard1.6/Smdn.Fundamental.UInt24n.dll" target="lib/netstandard1.6/Smdn.Fundamental.UInt24n.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/netstandard2.1/Smdn.Fundamental.UInt24n.dll" target="lib/netstandard2.1/Smdn.Fundamental.UInt24n.dll" />
    <file src="/home/runner/.nuget/packages/smdn.msbuild.projectassets.common/1.1.0/project/images/package-icon.png" target="Smdn.Fundamental.UInt24n.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

<!-- RELEASE NOTE -->
# Packages
- NuGet [Smdn.Fundamental.UInt24n version 3.0.2](https://www.nuget.org/packages/Smdn.Fundamental.UInt24n/3.0.2)

# Changes in this release
## Change log
- 2022-02-20 [update assembly version](https://github.com/smdn/Smdn.Fundamentals/commit/ba1968924b0078e56f5205dd0ae2468ee96e6071)
- 2022-02-04 [improve implementation of UIntXX.IConvertible.ToDateTime](https://github.com/smdn/Smdn.Fundamentals/commit/7550434425ff2da8b8c88c8124096a473ec4b688)
- 2022-02-04 [overload relational operators](https://github.com/smdn/Smdn.Fundamentals/commit/9e62d5d6b9009123a82132581ada69515de5d345)
- 2022-01-02 [define PackageTags](https://github.com/smdn/Smdn.Fundamentals/commit/81012f2f141eeeb5a771c348155efde8b13addd7)
- 2022-01-02 [refactor assembly attributes and package properties](https://github.com/smdn/Smdn.Fundamentals/commit/fb53ac2436caadd4dc156bb9e928250d5834e793)
- 2021-12-12 [add title for rule ID](https://github.com/smdn/Smdn.Fundamentals/commit/6e8ed8167b28d207fd795f3af9729580c6e75707)

## API diff
<details>
<summary>API diff in this release</summary>
<div>

```diff
diff --git a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-net45.apilist.cs b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-net45.apilist.cs
index 74cbb087..2cdb8a96 100644
--- a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-net45.apilist.cs
@@ -1,156 +1,164 @@
-// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.0.1 (net45))
+// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.0.2)
 //   Name: Smdn.Fundamental.UInt24n
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (net45)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+ba1968924b0078e56f5205dd0ae2468ee96e6071
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 
 using System;
 using Smdn;
 
 namespace Smdn {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
   public struct UInt24 :
     IComparable,
     IComparable<UInt24>,
     IComparable<int>,
     IComparable<uint>,
     IConvertible,
     IEquatable<UInt24>,
     IEquatable<int>,
     IEquatable<uint>,
     IFormattable
   {
     [FieldOffset(0)]
     public byte Byte0;
     [FieldOffset(1)]
     public byte Byte1;
     [FieldOffset(2)]
     public byte Byte2;
     public static readonly UInt24 MaxValue; // = "16777215"
     public static readonly UInt24 MinValue; // = "0"
     public static readonly UInt24 Zero; // = "0"
 
     public UInt24(byte[] @value, int startIndex, bool isBigEndian = false) {}
 
     public int CompareTo(UInt24 other) {}
     public int CompareTo(int other) {}
     public int CompareTo(object obj) {}
     public int CompareTo(uint other) {}
     public bool Equals(UInt24 other) {}
     public bool Equals(int other) {}
     public bool Equals(uint other) {}
     public override bool Equals(object obj) {}
     public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
     byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
     short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
     long IConvertible.ToInt64(IFormatProvider provider) {}
     sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
     ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
     ulong IConvertible.ToUInt64(IFormatProvider provider) {}
     public int ToInt32() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
     public uint ToUInt32() {}
     public static bool operator == (UInt24 x, UInt24 y) {}
     public static explicit operator UInt24(int val) {}
     public static explicit operator UInt24(short val) {}
     public static explicit operator UInt24(uint val) {}
     public static explicit operator UInt24(ushort val) {}
     public static explicit operator int(UInt24 val) {}
     public static explicit operator short(UInt24 val) {}
     public static explicit operator uint(UInt24 val) {}
     public static explicit operator ushort(UInt24 val) {}
+    public static bool operator > (UInt24 x, UInt24 y) {}
+    public static bool operator >= (UInt24 x, UInt24 y) {}
     public static bool operator != (UInt24 x, UInt24 y) {}
+    public static bool operator < (UInt24 x, UInt24 y) {}
+    public static bool operator <= (UInt24 x, UInt24 y) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
   public struct UInt48 :
     IComparable,
     IComparable<UInt48>,
     IComparable<long>,
     IComparable<ulong>,
     IConvertible,
     IEquatable<UInt48>,
     IEquatable<long>,
     IEquatable<ulong>,
     IFormattable
   {
     [FieldOffset(0)]
     public byte Byte0;
     [FieldOffset(1)]
     public byte Byte1;
     [FieldOffset(2)]
     public byte Byte2;
     [FieldOffset(3)]
     public byte Byte3;
     [FieldOffset(4)]
     public byte Byte4;
     [FieldOffset(5)]
     public byte Byte5;
     public static readonly UInt48 MaxValue; // = "281474976710655"
     public static readonly UInt48 MinValue; // = "0"
     public static readonly UInt48 Zero; // = "0"
 
     public UInt48(byte[] @value, int startIndex, bool isBigEndian = false) {}
 
     public int CompareTo(UInt48 other) {}
     public int CompareTo(long other) {}
     public int CompareTo(object obj) {}
     public int CompareTo(ulong other) {}
     public bool Equals(UInt48 other) {}
     public bool Equals(long other) {}
     public bool Equals(ulong other) {}
     public override bool Equals(object obj) {}
     public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
     byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
     short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
     long IConvertible.ToInt64(IFormatProvider provider) {}
     sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
     ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
     ulong IConvertible.ToUInt64(IFormatProvider provider) {}
     public long ToInt64() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
     public ulong ToUInt64() {}
     public static bool operator == (UInt48 x, UInt48 y) {}
     public static explicit operator UInt48(int val) {}
     public static explicit operator UInt48(long val) {}
     public static explicit operator UInt48(uint val) {}
     public static explicit operator UInt48(ulong val) {}
     public static explicit operator int(UInt48 val) {}
     public static explicit operator long(UInt48 val) {}
     public static explicit operator uint(UInt48 val) {}
     public static explicit operator ulong(UInt48 val) {}
+    public static bool operator > (UInt48 x, UInt48 y) {}
+    public static bool operator >= (UInt48 x, UInt48 y) {}
     public static bool operator != (UInt48 x, UInt48 y) {}
+    public static bool operator < (UInt48 x, UInt48 y) {}
+    public static bool operator <= (UInt48 x, UInt48 y) {}
   }
 }
 
diff --git a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard1.6.apilist.cs b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard1.6.apilist.cs
index 99ce314b..f0e69fcb 100644
--- a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard1.6.apilist.cs
@@ -1,156 +1,164 @@
-// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.0.1 (netstandard1.6))
+// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.0.2)
 //   Name: Smdn.Fundamental.UInt24n
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (netstandard1.6)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+ba1968924b0078e56f5205dd0ae2468ee96e6071
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 
 using System;
 using Smdn;
 
 namespace Smdn {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
   public struct UInt24 :
     IComparable,
     IComparable<UInt24>,
     IComparable<int>,
     IComparable<uint>,
     IConvertible,
     IEquatable<UInt24>,
     IEquatable<int>,
     IEquatable<uint>,
     IFormattable
   {
     [FieldOffset(0)]
     public byte Byte0;
     [FieldOffset(1)]
     public byte Byte1;
     [FieldOffset(2)]
     public byte Byte2;
     public static readonly UInt24 MaxValue; // = "16777215"
     public static readonly UInt24 MinValue; // = "0"
     public static readonly UInt24 Zero; // = "0"
 
     public UInt24(byte[] @value, int startIndex, bool isBigEndian = false) {}
 
     public int CompareTo(UInt24 other) {}
     public int CompareTo(int other) {}
     public int CompareTo(object obj) {}
     public int CompareTo(uint other) {}
     public bool Equals(UInt24 other) {}
     public bool Equals(int other) {}
     public bool Equals(uint other) {}
     public override bool Equals(object obj) {}
     public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
     byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
     short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
     long IConvertible.ToInt64(IFormatProvider provider) {}
     sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
     ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
     ulong IConvertible.ToUInt64(IFormatProvider provider) {}
     public int ToInt32() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
     public uint ToUInt32() {}
     public static bool operator == (UInt24 x, UInt24 y) {}
     public static explicit operator UInt24(int val) {}
     public static explicit operator UInt24(short val) {}
     public static explicit operator UInt24(uint val) {}
     public static explicit operator UInt24(ushort val) {}
     public static explicit operator int(UInt24 val) {}
     public static explicit operator short(UInt24 val) {}
     public static explicit operator uint(UInt24 val) {}
     public static explicit operator ushort(UInt24 val) {}
+    public static bool operator > (UInt24 x, UInt24 y) {}
+    public static bool operator >= (UInt24 x, UInt24 y) {}
     public static bool operator != (UInt24 x, UInt24 y) {}
+    public static bool operator < (UInt24 x, UInt24 y) {}
+    public static bool operator <= (UInt24 x, UInt24 y) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
   public struct UInt48 :
     IComparable,
     IComparable<UInt48>,
     IComparable<long>,
     IComparable<ulong>,
     IConvertible,
     IEquatable<UInt48>,
     IEquatable<long>,
     IEquatable<ulong>,
     IFormattable
   {
     [FieldOffset(0)]
     public byte Byte0;
     [FieldOffset(1)]
     public byte Byte1;
     [FieldOffset(2)]
     public byte Byte2;
     [FieldOffset(3)]
     public byte Byte3;
     [FieldOffset(4)]
     public byte Byte4;
     [FieldOffset(5)]
     public byte Byte5;
     public static readonly UInt48 MaxValue; // = "281474976710655"
     public static readonly UInt48 MinValue; // = "0"
     public static readonly UInt48 Zero; // = "0"
 
     public UInt48(byte[] @value, int startIndex, bool isBigEndian = false) {}
 
     public int CompareTo(UInt48 other) {}
     public int CompareTo(long other) {}
     public int CompareTo(object obj) {}
     public int CompareTo(ulong other) {}
     public bool Equals(UInt48 other) {}
     public bool Equals(long other) {}
     public bool Equals(ulong other) {}
     public override bool Equals(object obj) {}
     public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
     byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
     short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
     long IConvertible.ToInt64(IFormatProvider provider) {}
     sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
     ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
     ulong IConvertible.ToUInt64(IFormatProvider provider) {}
     public long ToInt64() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
     public ulong ToUInt64() {}
     public static bool operator == (UInt48 x, UInt48 y) {}
     public static explicit operator UInt48(int val) {}
     public static explicit operator UInt48(long val) {}
     public static explicit operator UInt48(uint val) {}
     public static explicit operator UInt48(ulong val) {}
     public static explicit operator int(UInt48 val) {}
     public static explicit operator long(UInt48 val) {}
     public static explicit operator uint(UInt48 val) {}
     public static explicit operator ulong(UInt48 val) {}
+    public static bool operator > (UInt48 x, UInt48 y) {}
+    public static bool operator >= (UInt48 x, UInt48 y) {}
     public static bool operator != (UInt48 x, UInt48 y) {}
+    public static bool operator < (UInt48 x, UInt48 y) {}
+    public static bool operator <= (UInt48 x, UInt48 y) {}
   }
 }
 
diff --git a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard2.1.apilist.cs b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard2.1.apilist.cs
index 10d7aede..eb056499 100644
--- a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard2.1.apilist.cs
@@ -1,156 +1,164 @@
-// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.0.1 (netstandard2.1))
+// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.0.2)
 //   Name: Smdn.Fundamental.UInt24n
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (netstandard2.1)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+ba1968924b0078e56f5205dd0ae2468ee96e6071
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
 using System;
 using Smdn;
 
 namespace Smdn {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
   public struct UInt24 :
     IComparable,
     IComparable<UInt24>,
     IComparable<int>,
     IComparable<uint>,
     IConvertible,
     IEquatable<UInt24>,
     IEquatable<int>,
     IEquatable<uint>,
     IFormattable
   {
     [FieldOffset(0)]
     public byte Byte0;
     [FieldOffset(1)]
     public byte Byte1;
     [FieldOffset(2)]
     public byte Byte2;
     public static readonly UInt24 MaxValue; // = "16777215"
     public static readonly UInt24 MinValue; // = "0"
     public static readonly UInt24 Zero; // = "0"
 
     public UInt24(byte[] @value, int startIndex, bool isBigEndian = false) {}
 
     public int CompareTo(UInt24 other) {}
     public int CompareTo(int other) {}
     public int CompareTo(object obj) {}
     public int CompareTo(uint other) {}
     public bool Equals(UInt24 other) {}
     public bool Equals(int other) {}
     public bool Equals(uint other) {}
     public override bool Equals(object obj) {}
     public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
     byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
     short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
     long IConvertible.ToInt64(IFormatProvider provider) {}
     sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
     ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
     ulong IConvertible.ToUInt64(IFormatProvider provider) {}
     public int ToInt32() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
     public uint ToUInt32() {}
     public static bool operator == (UInt24 x, UInt24 y) {}
     public static explicit operator UInt24(int val) {}
     public static explicit operator UInt24(short val) {}
     public static explicit operator UInt24(uint val) {}
     public static explicit operator UInt24(ushort val) {}
     public static explicit operator int(UInt24 val) {}
     public static explicit operator short(UInt24 val) {}
     public static explicit operator uint(UInt24 val) {}
     public static explicit operator ushort(UInt24 val) {}
+    public static bool operator > (UInt24 x, UInt24 y) {}
+    public static bool operator >= (UInt24 x, UInt24 y) {}
     public static bool operator != (UInt24 x, UInt24 y) {}
+    public static bool operator < (UInt24 x, UInt24 y) {}
+    public static bool operator <= (UInt24 x, UInt24 y) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
   public struct UInt48 :
     IComparable,
     IComparable<UInt48>,
     IComparable<long>,
     IComparable<ulong>,
     IConvertible,
     IEquatable<UInt48>,
     IEquatable<long>,
     IEquatable<ulong>,
     IFormattable
   {
     [FieldOffset(0)]
     public byte Byte0;
     [FieldOffset(1)]
     public byte Byte1;
     [FieldOffset(2)]
     public byte Byte2;
     [FieldOffset(3)]
     public byte Byte3;
     [FieldOffset(4)]
     public byte Byte4;
     [FieldOffset(5)]
     public byte Byte5;
     public static readonly UInt48 MaxValue; // = "281474976710655"
     public static readonly UInt48 MinValue; // = "0"
     public static readonly UInt48 Zero; // = "0"
 
     public UInt48(byte[] @value, int startIndex, bool isBigEndian = false) {}
 
     public int CompareTo(UInt48 other) {}
     public int CompareTo(long other) {}
     public int CompareTo(object obj) {}
     public int CompareTo(ulong other) {}
     public bool Equals(UInt48 other) {}
     public bool Equals(long other) {}
     public bool Equals(ulong other) {}
     public override bool Equals(object obj) {}
     public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
     byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
     short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
     long IConvertible.ToInt64(IFormatProvider provider) {}
     sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
     ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
     ulong IConvertible.ToUInt64(IFormatProvider provider) {}
     public long ToInt64() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
     public ulong ToUInt64() {}
     public static bool operator == (UInt48 x, UInt48 y) {}
     public static explicit operator UInt48(int val) {}
     public static explicit operator UInt48(long val) {}
     public static explicit operator UInt48(uint val) {}
     public static explicit operator UInt48(ulong val) {}
     public static explicit operator int(UInt48 val) {}
     public static explicit operator long(UInt48 val) {}
     public static explicit operator uint(UInt48 val) {}
     public static explicit operator ulong(UInt48 val) {}
+    public static bool operator > (UInt48 x, UInt48 y) {}
+    public static bool operator >= (UInt48 x, UInt48 y) {}
     public static bool operator != (UInt48 x, UInt48 y) {}
+    public static bool operator < (UInt48 x, UInt48 y) {}
+    public static bool operator <= (UInt48 x, UInt48 y) {}
   }
 }
 
```

</div>
</details>

## Changes
[Compare changes](https://github.com/smdn/Smdn.Fundamentals/compare/releases/Smdn.Fundamental.UInt24n-3.0.1..releases/Smdn.Fundamental.UInt24n-3.0.2)

<details>
<summary>Changes in this release</summary>
<div>

```diff
diff --git a/src/Smdn.Fundamental.UInt24n/.editorconfig b/src/Smdn.Fundamental.UInt24n/.editorconfig
index 5b15e613..ccce41ac 100644
--- a/src/Smdn.Fundamental.UInt24n/.editorconfig
+++ b/src/Smdn.Fundamental.UInt24n/.editorconfig
@@ -5,6 +5,6 @@ dotnet_diagnostic.SA1121.severity = none # Use built-in type alias
 dotnet_diagnostic.SA1129.severity = none # Do not use default value type constructor
 dotnet_diagnostic.SA1303.severity = none # Const field names should begin with upper-case letter
 
-dotnet_diagnostic.IDE0004.severity = none
-dotnet_diagnostic.IDE0047.severity = none
-dotnet_diagnostic.IDE0049.severity = none
+dotnet_diagnostic.IDE0004.severity = none # Remove unnecessary cast
+dotnet_diagnostic.IDE0047.severity = none # Remove unnecessary parentheses
+dotnet_diagnostic.IDE0049.severity = none # Use language keywords instead of framework type names for type references
diff --git a/src/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n.csproj b/src/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n.csproj
index b614780f..20a86022 100644
--- a/src/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n.csproj
+++ b/src/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n.csproj
@@ -5,16 +5,17 @@ SPDX-License-Identifier: MIT
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.1;netstandard1.6</TargetFrameworks>
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <VersionPrefix>3.0.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
-  <PropertyGroup Label="metadata">
+  <PropertyGroup Label="assembly attributes">
     <CopyrightYear>2021</CopyrightYear>
+  </PropertyGroup>
 
-    <!-- NuGet -->
-    <!--<PackageTags></PackageTags>-->
+  <PropertyGroup Label="package properties">
+    <PackageTags>uint24;uint48;24bit;48bit;interger</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
diff --git a/src/Smdn.Fundamental.UInt24n/Smdn/UInt24.cs b/src/Smdn.Fundamental.UInt24n/Smdn/UInt24.cs
index c54e0aa9..a4f63d4c 100644
--- a/src/Smdn.Fundamental.UInt24n/Smdn/UInt24.cs
+++ b/src/Smdn.Fundamental.UInt24n/Smdn/UInt24.cs
@@ -153,7 +153,8 @@ public struct UInt24 :
   bool IConvertible.ToBoolean(IFormatProvider provider) => Convert.ToBoolean(ToUInt32());
   char IConvertible.ToChar(IFormatProvider provider) => Convert.ToChar(ToUInt32());
 
-  DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convert.ToDateTime(ToUInt32());
+  DateTime IConvertible.ToDateTime(IFormatProvider provider) => ((IConvertible)ToUInt32()).ToDateTime(provider);
+
   decimal IConvertible.ToDecimal(IFormatProvider provider) => Convert.ToDecimal(ToUInt32());
 
   double IConvertible.ToDouble(IFormatProvider provider) => Convert.ToDouble(ToUInt32());
@@ -183,6 +184,11 @@ public struct UInt24 :
 
   public int CompareTo(int other) => this.ToInt32().CompareTo(other);
 
+  public static bool operator <(UInt24 x, UInt24 y) => x.ToUInt32() < y.ToUInt32();
+  public static bool operator <=(UInt24 x, UInt24 y) => x.ToUInt32() <= y.ToUInt32();
+  public static bool operator >(UInt24 x, UInt24 y) => x.ToUInt32() > y.ToUInt32();
+  public static bool operator >=(UInt24 x, UInt24 y) => x.ToUInt32() >= y.ToUInt32();
+
   public bool Equals(UInt24 other) => this == other;
 
   [CLSCompliant(false)]
diff --git a/src/Smdn.Fundamental.UInt24n/Smdn/UInt48.cs b/src/Smdn.Fundamental.UInt24n/Smdn/UInt48.cs
index f688b633..c7fb1c2a 100644
--- a/src/Smdn.Fundamental.UInt24n/Smdn/UInt48.cs
+++ b/src/Smdn.Fundamental.UInt24n/Smdn/UInt48.cs
@@ -185,7 +185,7 @@ public struct UInt48 :
 
   char IConvertible.ToChar(IFormatProvider provider) => Convert.ToChar(ToUInt64());
 
-  DateTime IConvertible.ToDateTime(IFormatProvider provider) => Convert.ToDateTime(ToUInt64());
+  DateTime IConvertible.ToDateTime(IFormatProvider provider) => ((IConvertible)ToUInt64()).ToDateTime(provider);
 
   decimal IConvertible.ToDecimal(IFormatProvider provider) => Convert.ToDecimal(ToUInt64());
 
@@ -216,6 +216,11 @@ public struct UInt48 :
 
   public int CompareTo(long other) => this.ToInt64().CompareTo(other);
 
+  public static bool operator <(UInt48 x, UInt48 y) => x.ToUInt64() < y.ToUInt64();
+  public static bool operator <=(UInt48 x, UInt48 y) => x.ToUInt64() <= y.ToUInt64();
+  public static bool operator >(UInt48 x, UInt48 y) => x.ToUInt64() > y.ToUInt64();
+  public static bool operator >=(UInt48 x, UInt48 y) => x.ToUInt64() >= y.ToUInt64();
+
   public bool Equals(UInt48 other) => this == other;
 
   [CLSCompliant(false)]
```

</div>
</details>


