### PR TITLE
Release main/Smdn.Fundamental.Stream.Filtering-3.0.1

### DIFF
--- a/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-net45.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Stream.Filtering.dll (Smdn.Fundamental.Stream.Filtering-3.0.0 (net45))
+// Smdn.Fundamental.Stream.Filtering.dll (Smdn.Fundamental.Stream.Filtering-3.0.1)
 //   Name: Smdn.Fundamental.Stream.Filtering
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (net45)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+6c46ed4e09b48a74bff0ead44a7ab8664fcf0ef8
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 
@@ -78,7 +78,7 @@ namespace Smdn.IO.Streams.Filtering {
     protected const int DefaultBufferSize = 1024;
     protected const bool DefaultLeaveStreamOpen = false;
     protected const int MinimumBufferSize = 2;
-    public static readonly FilterStream.IFilter NullFilter; // = "Smdn.IO.Streams.Filtering.FilterStream+_NullFilter"
+    public static readonly FilterStream.IFilter NullFilter; // = "Smdn.IO.Streams.Filtering.FilterStream+NullFilterImpl"
 
     public FilterStream(Stream stream, FilterStream.IFilter filter, int bufferSize = 1024, bool leaveStreamOpen = false) {}
     public FilterStream(Stream stream, IEnumerable<FilterStream.IFilter> filters, int bufferSize = 1024, bool leaveStreamOpen = false) {}
@@ -97,6 +97,8 @@ namespace Smdn.IO.Streams.Filtering {
     public override Task FlushAsync(CancellationToken cancellationToken) {}
     public override int Read(byte[] buffer, int offset, int count) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+    protected virtual Task<int> ReadAsyncUnchecked(Memory<byte> destination, CancellationToken cancellationToken) {}
+    [Obsolete("use Memory<byte> version instead")]
     protected virtual Task<int> ReadAsyncUnchecked(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
     protected virtual int ReadUnchecked(byte[] buffer, int offset, int count) {}
     public override long Seek(long offset, SeekOrigin origin) {}

--- a/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-netstandard1.6.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Stream.Filtering.dll (Smdn.Fundamental.Stream.Filtering-3.0.0 (netstandard1.6))
+// Smdn.Fundamental.Stream.Filtering.dll (Smdn.Fundamental.Stream.Filtering-3.0.1)
 //   Name: Smdn.Fundamental.Stream.Filtering
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (netstandard1.6)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+6c46ed4e09b48a74bff0ead44a7ab8664fcf0ef8
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 
@@ -78,7 +78,7 @@ namespace Smdn.IO.Streams.Filtering {
     protected const int DefaultBufferSize = 1024;
     protected const bool DefaultLeaveStreamOpen = false;
     protected const int MinimumBufferSize = 2;
-    public static readonly FilterStream.IFilter NullFilter; // = "Smdn.IO.Streams.Filtering.FilterStream+_NullFilter"
+    public static readonly FilterStream.IFilter NullFilter; // = "Smdn.IO.Streams.Filtering.FilterStream+NullFilterImpl"
 
     public FilterStream(Stream stream, FilterStream.IFilter filter, int bufferSize = 1024, bool leaveStreamOpen = false) {}
     public FilterStream(Stream stream, IEnumerable<FilterStream.IFilter> filters, int bufferSize = 1024, bool leaveStreamOpen = false) {}
@@ -97,6 +97,8 @@ namespace Smdn.IO.Streams.Filtering {
     public override Task FlushAsync(CancellationToken cancellationToken) {}
     public override int Read(byte[] buffer, int offset, int count) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+    protected virtual Task<int> ReadAsyncUnchecked(Memory<byte> destination, CancellationToken cancellationToken) {}
+    [Obsolete("use Memory<byte> version instead")]
     protected virtual Task<int> ReadAsyncUnchecked(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
     protected virtual int ReadUnchecked(byte[] buffer, int offset, int count) {}
     public override long Seek(long offset, SeekOrigin origin) {}

--- a/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Stream.Filtering.dll (Smdn.Fundamental.Stream.Filtering-3.0.0 (netstandard2.1))
+// Smdn.Fundamental.Stream.Filtering.dll (Smdn.Fundamental.Stream.Filtering-3.0.1)
 //   Name: Smdn.Fundamental.Stream.Filtering
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (netstandard2.1)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+6c46ed4e09b48a74bff0ead44a7ab8664fcf0ef8
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
@@ -78,7 +78,7 @@ namespace Smdn.IO.Streams.Filtering {
     protected const int DefaultBufferSize = 1024;
     protected const bool DefaultLeaveStreamOpen = false;
     protected const int MinimumBufferSize = 2;
-    public static readonly FilterStream.IFilter NullFilter; // = "Smdn.IO.Streams.Filtering.FilterStream+_NullFilter"
+    public static readonly FilterStream.IFilter NullFilter; // = "Smdn.IO.Streams.Filtering.FilterStream+NullFilterImpl"
 
     public FilterStream(Stream stream, FilterStream.IFilter filter, int bufferSize = 1024, bool leaveStreamOpen = false) {}
     public FilterStream(Stream stream, IEnumerable<FilterStream.IFilter> filters, int bufferSize = 1024, bool leaveStreamOpen = false) {}
@@ -97,13 +97,17 @@ namespace Smdn.IO.Streams.Filtering {
     public override Task FlushAsync(CancellationToken cancellationToken) {}
     public override int Read(byte[] buffer, int offset, int count) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) {}
+    [Obsolete("use Memory<byte> version instead")]
     protected virtual Task<int> ReadAsyncUnchecked(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    protected virtual ValueTask<int> ReadAsyncUnchecked(Memory<byte> destination, CancellationToken cancellationToken) {}
     protected virtual int ReadUnchecked(byte[] buffer, int offset, int count) {}
     public override long Seek(long offset, SeekOrigin origin) {}
     public override void SetLength(long @value) {}
     protected void ThrowIfDisposed() {}
     public override void Write(byte[] buffer, int offset, int count) {}
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
   }
 }
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #39](https://github.com/smdn/Smdn.Fundamentals/actions/runs/1874113525).

# Release target
## Release target info
- package_target_tag: `new-release/main/Smdn.Fundamental.Stream.Filtering-3.0.1`
- package_id: `Smdn.Fundamental.Stream.Filtering`
- package_id_with_version: `Smdn.Fundamental.Stream.Filtering-3.0.1`
- package_version: `3.0.1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.Stream.Filtering-3.0.1-1645415033`
- release_tag: `releases/Smdn.Fundamental.Stream.Filtering-3.0.1`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- artifact_name_nupkg: `Smdn.Fundamental.Stream.Filtering.3.0.1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

## .nuspec
```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.Stream.Filtering</id>
    <version>3.0.1</version>
    <title>Smdn.Fundamental.Stream.Filtering</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.Stream.Filtering.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.Stream.Filtering.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp stream filtering</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="6c46ed4e09b48a74bff0ead44a7ab8664fcf0ef8" />
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.1">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Filtering/bin/Release/net45/Smdn.Fundamental.Stream.Filtering.dll" target="lib/net45/Smdn.Fundamental.Stream.Filtering.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Filtering/bin/Release/netstandard1.6/Smdn.Fundamental.Stream.Filtering.dll" target="lib/netstandard1.6/Smdn.Fundamental.Stream.Filtering.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Filtering/bin/Release/netstandard2.1/Smdn.Fundamental.Stream.Filtering.dll" target="lib/netstandard2.1/Smdn.Fundamental.Stream.Filtering.dll" />
    <file src="/home/runner/.nuget/packages/smdn.msbuild.projectassets.common/1.1.0/project/images/package-icon.png" target="Smdn.Fundamental.Stream.Filtering.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Filtering/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

<!-- RELEASE NOTE -->
# Packages
- NuGet [Smdn.Fundamental.Stream.Filtering version 3.0.1](https://www.nuget.org/packages/Smdn.Fundamental.Stream.Filtering/3.0.1)

# Changes in this release
## Change log
- 2022-02-21 [revert deletion of overload of byte[] version](https://github.com/smdn/Smdn.Fundamentals/commit/6c46ed4e09b48a74bff0ead44a7ab8664fcf0ef8)
- 2022-02-20 [update assembly version](https://github.com/smdn/Smdn.Fundamentals/commit/0bfbfea1578b9bd1e24684f32c11e23dfef90c17)
- 2022-02-07 [use .NET SDK API symbols instead](https://github.com/smdn/Smdn.Fundamentals/commit/1afd43b08232077d89a97e3efa3ba553ac22d86e)
- 2022-02-05 [add comment](https://github.com/smdn/Smdn.Fundamentals/commit/1cca7d7ba3fd7d634e40835672ce44bdcb8ddb56)
- 2022-02-05 [ensure to call overriden base method](https://github.com/smdn/Smdn.Fundamentals/commit/af5ef29dcdd9b584608759075274c816c0f152a1)
- 2022-02-04 [override Stream.WriteAsync(ReadOnlyMemory, CancellationToken)](https://github.com/smdn/Smdn.Fundamentals/commit/4e92c10d0cb181b0abfe19e81703a7f371bfca4a)
- 2022-02-04 [override Stream.ReadAsync(Memory, CancellationToken)](https://github.com/smdn/Smdn.Fundamentals/commit/057cf73d3738c5cfc68adcb20f268572a235f1bd)
- 2022-02-04 [use ReadAsync(Memory<byte>)](https://github.com/smdn/Smdn.Fundamentals/commit/9714a4e1b61a8d17ffe4fb88cff0362210a7560b)
- 2022-02-04 [ensure to call overriden base method](https://github.com/smdn/Smdn.Fundamentals/commit/3d61edead1ae5c51c5f448f8689a26347a65abb5)
- 2022-01-02 [define PackageTags](https://github.com/smdn/Smdn.Fundamentals/commit/81012f2f141eeeb5a771c348155efde8b13addd7)
- 2022-01-02 [refactor assembly attributes and package properties](https://github.com/smdn/Smdn.Fundamentals/commit/fb53ac2436caadd4dc156bb9e928250d5834e793)
- 2021-12-12 [enable package validation and define PackageValidationBaselineVersion](https://github.com/smdn/Smdn.Fundamentals/commit/316ff1d9e5f75a398d7aced03d63f5a7da5fa5e8)
- 2021-12-11 [use file-scoped namespace declaration](https://github.com/smdn/Smdn.Fundamentals/commit/2542ecae5e70a3d2daf638dade18bddb16543605)
- 2021-12-10 [follow the code analyzer rules](https://github.com/smdn/Smdn.Fundamentals/commit/d5e2770b3c34e3530dd71f25fc44e34d07627651)
- 2021-12-05 [modify to follow the code style rules](https://github.com/smdn/Smdn.Fundamentals/commit/a562029eb18ea239a2b10c12d1939ec1f8fdae18)

## API diff
<details>
<summary>API diff in this release</summary>
<div>

```diff
diff --git a/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-net45.apilist.cs b/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-net45.apilist.cs
index 16032d43..a7029111 100644
--- a/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-net45.apilist.cs
@@ -1,109 +1,111 @@
-// Smdn.Fundamental.Stream.Filtering.dll (Smdn.Fundamental.Stream.Filtering-3.0.0 (net45))
+// Smdn.Fundamental.Stream.Filtering.dll (Smdn.Fundamental.Stream.Filtering-3.0.1)
 //   Name: Smdn.Fundamental.Stream.Filtering
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (net45)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+6c46ed4e09b48a74bff0ead44a7ab8664fcf0ef8
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.IO.Streams.Filtering;
 
 namespace Smdn.IO.Streams.Filtering {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class FilterStream : Stream {
     public delegate void FilterAction(Span<byte> buffer, long offsetWithinFilter);
 
     public interface IFilter {
       long Length { get; }
       long Offset { get; }
 
       void Apply(Span<byte> buffer, long offsetWithinFilter);
     }
 
     public sealed class BitwiseAndFilter : SingleValueFilter {
       public BitwiseAndFilter(long offset, long length, byte @value) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public sealed class BitwiseNotFilter : Filter {
       public BitwiseNotFilter(long offset, long length) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public sealed class BitwiseOrFilter : SingleValueFilter {
       public BitwiseOrFilter(long offset, long length, byte @value) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public sealed class BitwiseXorFilter : SingleValueFilter {
       public BitwiseXorFilter(long offset, long length, byte @value) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public sealed class FillFilter : SingleValueFilter {
       public FillFilter(long offset, long length, byte @value) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public abstract class Filter : IFilter {
       protected Filter(long offset, long length) {}
 
       public long Length { get; }
       public long Offset { get; }
 
       public abstract void Apply(Span<byte> buffer, long offsetWithinFilter);
     }
 
     public abstract class SingleValueFilter : Filter {
       protected SingleValueFilter(long offset, long length, byte @value) {}
 
       public byte Value { get; }
     }
 
     public sealed class ZeroFilter : Filter {
       public ZeroFilter(long offset, long length) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     protected const int DefaultBufferSize = 1024;
     protected const bool DefaultLeaveStreamOpen = false;
     protected const int MinimumBufferSize = 2;
-    public static readonly FilterStream.IFilter NullFilter; // = "Smdn.IO.Streams.Filtering.FilterStream+_NullFilter"
+    public static readonly FilterStream.IFilter NullFilter; // = "Smdn.IO.Streams.Filtering.FilterStream+NullFilterImpl"
 
     public FilterStream(Stream stream, FilterStream.IFilter filter, int bufferSize = 1024, bool leaveStreamOpen = false) {}
     public FilterStream(Stream stream, IEnumerable<FilterStream.IFilter> filters, int bufferSize = 1024, bool leaveStreamOpen = false) {}
 
     public override bool CanRead { get; }
     public override bool CanSeek { get; }
     public override bool CanTimeout { get; }
     public override bool CanWrite { get; }
     public IReadOnlyList<FilterStream.IFilter> Filters { get; protected set; }
     public override long Length { get; }
     public override long Position { get; set; }
 
     public override void Close() {}
     public static FilterStream.Filter CreateFilter(long offset, long length, FilterStream.FilterAction filter) {}
     public override void Flush() {}
     public override Task FlushAsync(CancellationToken cancellationToken) {}
     public override int Read(byte[] buffer, int offset, int count) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+    protected virtual Task<int> ReadAsyncUnchecked(Memory<byte> destination, CancellationToken cancellationToken) {}
+    [Obsolete("use Memory<byte> version instead")]
     protected virtual Task<int> ReadAsyncUnchecked(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
     protected virtual int ReadUnchecked(byte[] buffer, int offset, int count) {}
     public override long Seek(long offset, SeekOrigin origin) {}
     public override void SetLength(long @value) {}
     protected void ThrowIfDisposed() {}
     public override void Write(byte[] buffer, int offset, int count) {}
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
   }
 }
 
diff --git a/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-netstandard1.6.apilist.cs b/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-netstandard1.6.apilist.cs
index 3b138b9c..b76ad604 100644
--- a/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-netstandard1.6.apilist.cs
@@ -1,109 +1,111 @@
-// Smdn.Fundamental.Stream.Filtering.dll (Smdn.Fundamental.Stream.Filtering-3.0.0 (netstandard1.6))
+// Smdn.Fundamental.Stream.Filtering.dll (Smdn.Fundamental.Stream.Filtering-3.0.1)
 //   Name: Smdn.Fundamental.Stream.Filtering
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (netstandard1.6)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+6c46ed4e09b48a74bff0ead44a7ab8664fcf0ef8
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.IO.Streams.Filtering;
 
 namespace Smdn.IO.Streams.Filtering {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class FilterStream : Stream {
     public delegate void FilterAction(Span<byte> buffer, long offsetWithinFilter);
 
     public interface IFilter {
       long Length { get; }
       long Offset { get; }
 
       void Apply(Span<byte> buffer, long offsetWithinFilter);
     }
 
     public sealed class BitwiseAndFilter : SingleValueFilter {
       public BitwiseAndFilter(long offset, long length, byte @value) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public sealed class BitwiseNotFilter : Filter {
       public BitwiseNotFilter(long offset, long length) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public sealed class BitwiseOrFilter : SingleValueFilter {
       public BitwiseOrFilter(long offset, long length, byte @value) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public sealed class BitwiseXorFilter : SingleValueFilter {
       public BitwiseXorFilter(long offset, long length, byte @value) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public sealed class FillFilter : SingleValueFilter {
       public FillFilter(long offset, long length, byte @value) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public abstract class Filter : IFilter {
       protected Filter(long offset, long length) {}
 
       public long Length { get; }
       public long Offset { get; }
 
       public abstract void Apply(Span<byte> buffer, long offsetWithinFilter);
     }
 
     public abstract class SingleValueFilter : Filter {
       protected SingleValueFilter(long offset, long length, byte @value) {}
 
       public byte Value { get; }
     }
 
     public sealed class ZeroFilter : Filter {
       public ZeroFilter(long offset, long length) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     protected const int DefaultBufferSize = 1024;
     protected const bool DefaultLeaveStreamOpen = false;
     protected const int MinimumBufferSize = 2;
-    public static readonly FilterStream.IFilter NullFilter; // = "Smdn.IO.Streams.Filtering.FilterStream+_NullFilter"
+    public static readonly FilterStream.IFilter NullFilter; // = "Smdn.IO.Streams.Filtering.FilterStream+NullFilterImpl"
 
     public FilterStream(Stream stream, FilterStream.IFilter filter, int bufferSize = 1024, bool leaveStreamOpen = false) {}
     public FilterStream(Stream stream, IEnumerable<FilterStream.IFilter> filters, int bufferSize = 1024, bool leaveStreamOpen = false) {}
 
     public override bool CanRead { get; }
     public override bool CanSeek { get; }
     public override bool CanTimeout { get; }
     public override bool CanWrite { get; }
     public IReadOnlyList<FilterStream.IFilter> Filters { get; protected set; }
     public override long Length { get; }
     public override long Position { get; set; }
 
     public static FilterStream.Filter CreateFilter(long offset, long length, FilterStream.FilterAction filter) {}
     protected override void Dispose(bool disposing) {}
     public override void Flush() {}
     public override Task FlushAsync(CancellationToken cancellationToken) {}
     public override int Read(byte[] buffer, int offset, int count) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+    protected virtual Task<int> ReadAsyncUnchecked(Memory<byte> destination, CancellationToken cancellationToken) {}
+    [Obsolete("use Memory<byte> version instead")]
     protected virtual Task<int> ReadAsyncUnchecked(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
     protected virtual int ReadUnchecked(byte[] buffer, int offset, int count) {}
     public override long Seek(long offset, SeekOrigin origin) {}
     public override void SetLength(long @value) {}
     protected void ThrowIfDisposed() {}
     public override void Write(byte[] buffer, int offset, int count) {}
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
   }
 }
 
diff --git a/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-netstandard2.1.apilist.cs b/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-netstandard2.1.apilist.cs
index 07519530..f6ba14b7 100644
--- a/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering-netstandard2.1.apilist.cs
@@ -1,109 +1,113 @@
-// Smdn.Fundamental.Stream.Filtering.dll (Smdn.Fundamental.Stream.Filtering-3.0.0 (netstandard2.1))
+// Smdn.Fundamental.Stream.Filtering.dll (Smdn.Fundamental.Stream.Filtering-3.0.1)
 //   Name: Smdn.Fundamental.Stream.Filtering
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (netstandard2.1)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+6c46ed4e09b48a74bff0ead44a7ab8664fcf0ef8
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.IO.Streams.Filtering;
 
 namespace Smdn.IO.Streams.Filtering {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class FilterStream : Stream {
     public delegate void FilterAction(Span<byte> buffer, long offsetWithinFilter);
 
     public interface IFilter {
       long Length { get; }
       long Offset { get; }
 
       void Apply(Span<byte> buffer, long offsetWithinFilter);
     }
 
     public sealed class BitwiseAndFilter : SingleValueFilter {
       public BitwiseAndFilter(long offset, long length, byte @value) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public sealed class BitwiseNotFilter : Filter {
       public BitwiseNotFilter(long offset, long length) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public sealed class BitwiseOrFilter : SingleValueFilter {
       public BitwiseOrFilter(long offset, long length, byte @value) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public sealed class BitwiseXorFilter : SingleValueFilter {
       public BitwiseXorFilter(long offset, long length, byte @value) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public sealed class FillFilter : SingleValueFilter {
       public FillFilter(long offset, long length, byte @value) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     public abstract class Filter : IFilter {
       protected Filter(long offset, long length) {}
 
       public long Length { get; }
       public long Offset { get; }
 
       public abstract void Apply(Span<byte> buffer, long offsetWithinFilter);
     }
 
     public abstract class SingleValueFilter : Filter {
       protected SingleValueFilter(long offset, long length, byte @value) {}
 
       public byte Value { get; }
     }
 
     public sealed class ZeroFilter : Filter {
       public ZeroFilter(long offset, long length) {}
 
       public override void Apply(Span<byte> buffer, long offsetWithinFilter) {}
     }
 
     protected const int DefaultBufferSize = 1024;
     protected const bool DefaultLeaveStreamOpen = false;
     protected const int MinimumBufferSize = 2;
-    public static readonly FilterStream.IFilter NullFilter; // = "Smdn.IO.Streams.Filtering.FilterStream+_NullFilter"
+    public static readonly FilterStream.IFilter NullFilter; // = "Smdn.IO.Streams.Filtering.FilterStream+NullFilterImpl"
 
     public FilterStream(Stream stream, FilterStream.IFilter filter, int bufferSize = 1024, bool leaveStreamOpen = false) {}
     public FilterStream(Stream stream, IEnumerable<FilterStream.IFilter> filters, int bufferSize = 1024, bool leaveStreamOpen = false) {}
 
     public override bool CanRead { get; }
     public override bool CanSeek { get; }
     public override bool CanTimeout { get; }
     public override bool CanWrite { get; }
     public IReadOnlyList<FilterStream.IFilter> Filters { get; protected set; }
     public override long Length { get; }
     public override long Position { get; set; }
 
     public override void Close() {}
     public static FilterStream.Filter CreateFilter(long offset, long length, FilterStream.FilterAction filter) {}
     public override void Flush() {}
     public override Task FlushAsync(CancellationToken cancellationToken) {}
     public override int Read(byte[] buffer, int offset, int count) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) {}
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) {}
+    [Obsolete("use Memory<byte> version instead")]
     protected virtual Task<int> ReadAsyncUnchecked(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    protected virtual ValueTask<int> ReadAsyncUnchecked(Memory<byte> destination, CancellationToken cancellationToken) {}
     protected virtual int ReadUnchecked(byte[] buffer, int offset, int count) {}
     public override long Seek(long offset, SeekOrigin origin) {}
     public override void SetLength(long @value) {}
     protected void ThrowIfDisposed() {}
     public override void Write(byte[] buffer, int offset, int count) {}
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
   }
 }
 
```

</div>
</details>

## Changes
[Compare changes](https://github.com/smdn/Smdn.Fundamentals/compare/releases/Smdn.Fundamental.Stream.Filtering-3.0.0..releases/Smdn.Fundamental.Stream.Filtering-3.0.1)

<details>
<summary>Changes in this release</summary>
<div>

```diff
diff --git a/src/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering.csproj b/src/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering.csproj
index c418b358..733d2756 100644
--- a/src/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering.csproj
+++ b/src/Smdn.Fundamental.Stream.Filtering/Smdn.Fundamental.Stream.Filtering.csproj
@@ -5,15 +5,17 @@ SPDX-License-Identifier: MIT
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.1;netstandard1.6</TargetFrameworks>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
+    <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
-  <PropertyGroup Label="metadata">
+  <PropertyGroup Label="assembly attributes">
     <CopyrightYear>2021</CopyrightYear>
+  </PropertyGroup>
 
-    <!-- NuGet -->
-    <!--<PackageTags></PackageTags>-->
+  <PropertyGroup Label="package properties">
+    <PackageTags>stream;filtering</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
diff --git a/src/Smdn.Fundamental.Stream.Filtering/Smdn.IO.Streams.Filtering/FilterStream.Filters.cs b/src/Smdn.Fundamental.Stream.Filtering/Smdn.IO.Streams.Filtering/FilterStream.Filters.cs
index 71343294..8189afbf 100644
--- a/src/Smdn.Fundamental.Stream.Filtering/Smdn.IO.Streams.Filtering/FilterStream.Filters.cs
+++ b/src/Smdn.Fundamental.Stream.Filtering/Smdn.IO.Streams.Filtering/FilterStream.Filters.cs
@@ -3,136 +3,136 @@
 using System;
 using System.IO;
 
-namespace Smdn.IO.Streams.Filtering {
-  public partial class FilterStream : Stream {
-    public interface IFilter {
-      long Offset { get; }
-      long Length { get; }
-      void Apply(Span<byte> buffer, long offsetWithinFilter);
-    }
+namespace Smdn.IO.Streams.Filtering;
 
-    private class _NullFilter : IFilter {
-      public long Offset => throw new NotSupportedException();
-      public long Length => throw new NotSupportedException();
-      public void Apply(Span<byte> buffer, long offsetWithinFilter) => throw new NotSupportedException();
-    }
+public partial class FilterStream : Stream {
+  public interface IFilter {
+    long Offset { get; }
+    long Length { get; }
+    void Apply(Span<byte> buffer, long offsetWithinFilter);
+  }
 
-    public static readonly IFilter NullFilter = new _NullFilter();
+  private class NullFilterImpl : IFilter {
+    public long Offset => throw new NotSupportedException();
+    public long Length => throw new NotSupportedException();
+    public void Apply(Span<byte> buffer, long offsetWithinFilter) => throw new NotSupportedException();
+  }
 
-    public abstract class Filter : IFilter {
-      public long Offset { get; }
-      public long Length { get; }
+  public static readonly IFilter NullFilter = new NullFilterImpl();
 
-      protected Filter(long offset, long length)
-      {
-        this.Offset = offset;
-        this.Length = 0 <= length ? length : throw ExceptionUtils.CreateArgumentMustBeZeroOrPositive(nameof(length), length);
-      }
+  public abstract class Filter : IFilter {
+    public long Offset { get; }
+    public long Length { get; }
 
-      public abstract void Apply(Span<byte> buffer, long offsetWithinFilter);
+    protected Filter(long offset, long length)
+    {
+      this.Offset = offset;
+      this.Length = 0 <= length ? length : throw ExceptionUtils.CreateArgumentMustBeZeroOrPositive(nameof(length), length);
     }
 
-    public delegate void FilterAction(Span<byte> buffer, long offsetWithinFilter);
+    public abstract void Apply(Span<byte> buffer, long offsetWithinFilter);
+  }
 
-    private class DelegatedFilter : Filter {
-      private readonly FilterAction filter;
+  public delegate void FilterAction(Span<byte> buffer, long offsetWithinFilter);
 
-      public DelegatedFilter(long offset, long length, FilterAction filter)
-        : base(offset, length)
-      {
-        this.filter = filter;
-      }
+  private class DelegatedFilter : Filter {
+    private readonly FilterAction filter;
 
-      public override void Apply(Span<byte> buffer, long offsetWithinFilter)
-        => filter(buffer, offsetWithinFilter);
+    public DelegatedFilter(long offset, long length, FilterAction filter)
+      : base(offset, length)
+    {
+      this.filter = filter;
     }
 
-    public static Filter CreateFilter(long offset, long length, FilterAction filter)
-      => new DelegatedFilter(offset, length, filter ?? throw new ArgumentNullException(nameof(filter)));
+    public override void Apply(Span<byte> buffer, long offsetWithinFilter)
+      => filter(buffer, offsetWithinFilter);
+  }
 
-    public abstract class SingleValueFilter : Filter {
-      public byte Value { get; }
+  public static Filter CreateFilter(long offset, long length, FilterAction filter)
+    => new DelegatedFilter(offset, length, filter ?? throw new ArgumentNullException(nameof(filter)));
 
-      protected SingleValueFilter(long offset, long length, byte value)
-        : base(offset, length)
-      {
-        this.Value = value;
-      }
-    }
+  public abstract class SingleValueFilter : Filter {
+    public byte Value { get; }
 
-    public sealed class FillFilter : SingleValueFilter {
-      public FillFilter(long offset, long length, byte value)
-        : base(offset, length, value)
-      {
-      }
+    protected SingleValueFilter(long offset, long length, byte value)
+      : base(offset, length)
+    {
+      this.Value = value;
+    }
+  }
 
-      public override void Apply(Span<byte> buffer, long offsetWithinFilter)
-        => buffer.Fill(Value);
+  public sealed class FillFilter : SingleValueFilter {
+    public FillFilter(long offset, long length, byte value)
+      : base(offset, length, value)
+    {
     }
 
-    public sealed class ZeroFilter : Filter {
-      public ZeroFilter(long offset, long length)
-        : base(offset, length)
-      {
-      }
+    public override void Apply(Span<byte> buffer, long offsetWithinFilter)
+      => buffer.Fill(Value);
+  }
 
-      public override void Apply(Span<byte> buffer, long offsetWithinFilter)
-        => buffer.Clear();
+  public sealed class ZeroFilter : Filter {
+    public ZeroFilter(long offset, long length)
+      : base(offset, length)
+    {
     }
 
-    public sealed class BitwiseNotFilter : Filter {
-      public BitwiseNotFilter(long offset, long length)
-        : base(offset, length)
-      {
-      }
+    public override void Apply(Span<byte> buffer, long offsetWithinFilter)
+      => buffer.Clear();
+  }
 
-      public override void Apply(Span<byte> buffer, long offsetWithinFilter)
-      {
-        for (var index = 0; index < buffer.Length; index++) {
-          buffer[index] = (byte)~buffer[index];
-        }
-      }
+  public sealed class BitwiseNotFilter : Filter {
+    public BitwiseNotFilter(long offset, long length)
+      : base(offset, length)
+    {
     }
 
-    public sealed class BitwiseOrFilter : SingleValueFilter {
-      public BitwiseOrFilter(long offset, long length, byte value)
-        : base(offset, length, value)
-      {
+    public override void Apply(Span<byte> buffer, long offsetWithinFilter)
+    {
+      for (var index = 0; index < buffer.Length; index++) {
+        buffer[index] = (byte)~buffer[index];
       }
+    }
+  }
 
-      public override void Apply(Span<byte> buffer, long offsetWithinFilter)
-      {
-        for (var index = 0; index < buffer.Length; index++) {
-          buffer[index] |= Value;
-        }
-      }
+  public sealed class BitwiseOrFilter : SingleValueFilter {
+    public BitwiseOrFilter(long offset, long length, byte value)
+      : base(offset, length, value)
+    {
     }
 
-    public sealed class BitwiseAndFilter : SingleValueFilter {
-      public BitwiseAndFilter(long offset, long length, byte value)
-        : base(offset, length, value)
-      {
+    public override void Apply(Span<byte> buffer, long offsetWithinFilter)
+    {
+      for (var index = 0; index < buffer.Length; index++) {
+        buffer[index] |= Value;
       }
+    }
+  }
 
-      public override void Apply(Span<byte> buffer, long offsetWithinFilter)
-      {
-        for (var index = 0; index < buffer.Length; index++) {
-          buffer[index] &= Value;
-        }
-      }
+  public sealed class BitwiseAndFilter : SingleValueFilter {
+    public BitwiseAndFilter(long offset, long length, byte value)
+      : base(offset, length, value)
+    {
     }
 
-    public sealed class BitwiseXorFilter : SingleValueFilter {
-      public BitwiseXorFilter(long offset, long length, byte value)
-        : base(offset, length, value)
-      {
+    public override void Apply(Span<byte> buffer, long offsetWithinFilter)
+    {
+      for (var index = 0; index < buffer.Length; index++) {
+        buffer[index] &= Value;
       }
+    }
+  }
+
+  public sealed class BitwiseXorFilter : SingleValueFilter {
+    public BitwiseXorFilter(long offset, long length, byte value)
+      : base(offset, length, value)
+    {
+    }
 
-      public override void Apply(Span<byte> buffer, long offsetWithinFilter)
-      {
-        for (var index = 0; index < buffer.Length; index++) {
-          buffer[index] ^= Value;
-        }
+    public override void Apply(Span<byte> buffer, long offsetWithinFilter)
+    {
+      for (var index = 0; index < buffer.Length; index++) {
+        buffer[index] ^= Value;
       }
     }
   }
diff --git a/src/Smdn.Fundamental.Stream.Filtering/Smdn.IO.Streams.Filtering/FilterStream.cs b/src/Smdn.Fundamental.Stream.Filtering/Smdn.IO.Streams.Filtering/FilterStream.cs
index 59f4b0c6..9cf69499 100644
--- a/src/Smdn.Fundamental.Stream.Filtering/Smdn.IO.Streams.Filtering/FilterStream.cs
+++ b/src/Smdn.Fundamental.Stream.Filtering/Smdn.IO.Streams.Filtering/FilterStream.cs
@@ -7,270 +7,355 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Smdn.IO.Streams.Filtering {
-  [System.Runtime.CompilerServices.TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
-  public partial class FilterStream : Stream {
-    private Stream stream = null;
-    private bool IsClosed => stream == null;
-    public override bool CanSeek => !IsClosed && stream.CanSeek;
-    public override bool CanRead => !IsClosed && stream.CanRead;
-    public override bool CanWrite => /*!IsClosed &&*/ false;
-    public override bool CanTimeout => !IsClosed && stream.CanTimeout;
-    public override long Length { get { ThrowIfDisposed(); return stream.Length; } }
-    public override long Position {
-      get { ThrowIfDisposed(); return offset; }
-      set { ThrowIfDisposed(); AdvanceBufferTo(stream.Position = value); }
-    }
-
-    protected void ThrowIfDisposed()
-    {
-      if (stream == null)
-        throw new ObjectDisposedException(GetType().FullName);
-    }
-
-    private IReadOnlyList<IFilter> filters;
-    public IReadOnlyList<IFilter> Filters {
-      get => filters;
-      protected set => throw new NotImplementedException();
-    }
+namespace Smdn.IO.Streams.Filtering;
+
+[System.Runtime.CompilerServices.TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
+public partial class FilterStream : Stream {
+  private Stream stream = null;
+  private bool IsClosed => stream == null;
+  public override bool CanSeek => !IsClosed && stream.CanSeek;
+  public override bool CanRead => !IsClosed && stream.CanRead;
+  public override bool CanWrite => /*!IsClosed &&*/ false;
+  public override bool CanTimeout => !IsClosed && stream.CanTimeout;
+  public override long Length { get { ThrowIfDisposed(); return stream.Length; } }
+  public override long Position {
+    get { ThrowIfDisposed(); return offset; }
+    set { ThrowIfDisposed(); AdvanceBufferTo(stream.Position = value); }
+  }
 
-    private readonly bool leaveStreamOpen;
-    protected const bool DefaultLeaveStreamOpen = false;
+  protected void ThrowIfDisposed()
+  {
+    if (stream == null)
+      throw new ObjectDisposedException(GetType().FullName);
+  }
 
-    protected const int DefaultBufferSize = 1024;
-    protected const int MinimumBufferSize = 2;
+  private readonly IReadOnlyList<IFilter> filters;
+  public IReadOnlyList<IFilter> Filters {
+    get => filters;
+    protected set => throw new NotImplementedException();
+  }
 
-    public FilterStream(
-      Stream stream,
-      IFilter filter,
-      int bufferSize = DefaultBufferSize,
-      bool leaveStreamOpen = DefaultLeaveStreamOpen
+  private readonly bool leaveStreamOpen;
+  protected const bool DefaultLeaveStreamOpen = false;
+
+  protected const int DefaultBufferSize = 1024;
+  protected const int MinimumBufferSize = 2;
+
+  public FilterStream(
+    Stream stream,
+    IFilter filter,
+    int bufferSize = DefaultBufferSize,
+    bool leaveStreamOpen = DefaultLeaveStreamOpen
+  )
+    : this(
+      stream,
+      Enumerable.Repeat(filter ?? throw new ArgumentNullException(nameof(filter)), 1),
+      bufferSize,
+      leaveStreamOpen
     )
-      : this(
-        stream,
-        Enumerable.Repeat(filter ?? throw new ArgumentNullException(nameof(filter)), 1),
-        bufferSize,
-        leaveStreamOpen
-      )
-    {
-    }
+  {
+  }
 
-    public FilterStream(
-      Stream stream,
-      IEnumerable<IFilter> filters,
-      int bufferSize = DefaultBufferSize,
-      bool leaveStreamOpen = DefaultLeaveStreamOpen
-    )
-    {
-      this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
-      this.filters = filters.Where(f => !(f is _NullFilter)).ToList() ?? throw new ArgumentNullException(nameof(filters));
-      this.leaveStreamOpen = leaveStreamOpen;
-      this.rawBuffer = new byte[
-        MinimumBufferSize <= bufferSize
-          ? bufferSize
-          : throw ExceptionUtils.CreateArgumentMustBeGreaterThanOrEqualTo(MinimumBufferSize, nameof(bufferSize), bufferSize)
-      ];
-
-      AdvanceBufferTo(stream.CanSeek ? stream.Position : 0L);
-    }
+  public FilterStream(
+    Stream stream,
+    IEnumerable<IFilter> filters,
+    int bufferSize = DefaultBufferSize,
+    bool leaveStreamOpen = DefaultLeaveStreamOpen
+  )
+  {
+    this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
+    this.filters = filters.Where(f => f is not NullFilterImpl).ToList() ?? throw new ArgumentNullException(nameof(filters));
+    this.leaveStreamOpen = leaveStreamOpen;
+    this.rawBuffer = new byte[
+      MinimumBufferSize <= bufferSize
+        ? bufferSize
+        : throw ExceptionUtils.CreateArgumentMustBeGreaterThanOrEqualTo(MinimumBufferSize, nameof(bufferSize), bufferSize)
+    ];
+
+    AdvanceBufferTo(stream.CanSeek ? stream.Position : 0L);
+  }
 
 #if SYSTEM_IO_STREAM_CLOSE
-    public override void Close()
+  public override void Close()
 #else
-    protected override void Dispose(bool disposing)
+  protected override void Dispose(bool disposing)
 #endif
-    {
-      if (!leaveStreamOpen)
+  {
+    if (!leaveStreamOpen)
 #if SYSTEM_IO_STREAM_CLOSE
-        stream?.Close();
+      stream?.Close();
 #else
-        stream?.Dispose();
+      stream?.Dispose();
 #endif
 
-      stream = null;
-    }
-
-    private Task ThrowNotSupportedWritingStream() { ThrowIfDisposed(); throw ExceptionUtils.CreateNotSupportedWritingStream(); }
+    stream = null;
 
-    public override void Flush() => ThrowNotSupportedWritingStream();
-    public override Task FlushAsync(CancellationToken cancellationToken) => ThrowNotSupportedWritingStream();
+#if SYSTEM_IO_STREAM_CLOSE
+    base.Close();
+#else
+    base.Dispose(disposing);
+#endif
+  }
 
-    public override void Write(byte[] buffer, int offset, int count) => ThrowNotSupportedWritingStream();
-    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => ThrowNotSupportedWritingStream();
+  private Task ThrowNotSupportedWritingStream() { ThrowIfDisposed(); throw ExceptionUtils.CreateNotSupportedWritingStream(); }
+#if SYSTEM_IO_STREAM_WRITEASYNC_READONLYMEMORY_OF_BYTE
+  private ValueTask ThrowNotSupportedWritingStreamValueTask() { ThrowIfDisposed(); throw ExceptionUtils.CreateNotSupportedWritingStream(); }
+#endif
 
-    public override void SetLength(long value) { ThrowIfDisposed(); throw ExceptionUtils.CreateNotSupportedSettingStreamLength(); }
+  public override void Flush() => ThrowNotSupportedWritingStream();
+  public override Task FlushAsync(CancellationToken cancellationToken) => ThrowNotSupportedWritingStream();
 
-    public override long Seek(long offset, SeekOrigin origin)
-    {
-      ThrowIfDisposed();
+  public override void Write(byte[] buffer, int offset, int count) => ThrowNotSupportedWritingStream();
+  public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => ThrowNotSupportedWritingStream();
+#if SYSTEM_IO_STREAM_WRITEASYNC_READONLYMEMORY_OF_BYTE
+  public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => ThrowNotSupportedWritingStreamValueTask();
+#endif
+  public override void SetLength(long value) { ThrowIfDisposed(); throw ExceptionUtils.CreateNotSupportedSettingStreamLength(); }
 
-      return AdvanceBufferTo(stream.Seek(offset, origin));
-    }
+  public override long Seek(long offset, SeekOrigin origin)
+  {
+    ThrowIfDisposed();
 
-    public override int Read(byte[] buffer, int offset, int count)
-    {
-      ThrowIfDisposed();
-
-      if (buffer == null)
-        throw new ArgumentNullException(nameof(buffer));
-      if (count < 0)
-        throw ExceptionUtils.CreateArgumentMustBeZeroOrPositive(nameof(count), count);
-      if (offset < 0)
-        throw ExceptionUtils.CreateArgumentMustBeZeroOrPositive(nameof(offset), offset);
-      if (buffer.Length < count + offset)
-        throw ExceptionUtils.CreateArgumentAttemptToAccessBeyondEndOfArray(nameof(offset), buffer, offset, count);
-
-      return ReadUnchecked(buffer, offset, count);
-    }
+    return AdvanceBufferTo(stream.Seek(offset, origin));
+  }
 
-    protected virtual int ReadUnchecked(byte[] buffer, int offset, int count)
-    {
-      var read = 0;
-      var dest = buffer.AsMemory(offset, count);
+  public override int Read(byte[] buffer, int offset, int count)
+  {
+    ThrowIfDisposed();
 
-      for (; ; ) {
-        if (bufferReadCursor.Length == 0) {
-          if (hasReachedEndOfStream)
-            return read;
+    if (buffer == null)
+      throw new ArgumentNullException(nameof(buffer));
+    if (count < 0)
+      throw ExceptionUtils.CreateArgumentMustBeZeroOrPositive(nameof(count), count);
+    if (offset < 0)
+      throw ExceptionUtils.CreateArgumentMustBeZeroOrPositive(nameof(offset), offset);
+    if (buffer.Length < count + offset)
+      throw ExceptionUtils.CreateArgumentAttemptToAccessBeyondEndOfArray(nameof(offset), buffer, offset, count);
 
-          FillBuffer();
-        }
+    return ReadUnchecked(buffer, offset, count);
+  }
 
-        read += ReadBuffer(ref dest);
+  protected virtual int ReadUnchecked(byte[] buffer, int offset, int count)
+  {
+    var read = 0;
+    var dest = buffer.AsMemory(offset, count);
 
-        if (dest.Length == 0)
+    for (; ; ) {
+      if (bufferReadCursor.Length == 0) {
+        if (hasReachedEndOfStream)
           return read;
+
+        FillBuffer();
       }
+
+      read += ReadBuffer(ref dest);
+
+      if (dest.Length == 0)
+        return read;
     }
+  }
 
-    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
-    {
-      ThrowIfDisposed();
-
-      if (buffer == null)
-        throw new ArgumentNullException(nameof(buffer));
-      if (count < 0)
-        throw ExceptionUtils.CreateArgumentMustBeZeroOrPositive(nameof(count), count);
-      if (offset < 0)
-        throw ExceptionUtils.CreateArgumentMustBeZeroOrPositive(nameof(offset), offset);
-      if (buffer.Length < count + offset)
-        throw ExceptionUtils.CreateArgumentAttemptToAccessBeyondEndOfArray(nameof(offset), buffer, offset, count);
-
-      if (cancellationToken.IsCancellationRequested)
+  public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
+  {
+    ThrowIfDisposed();
+
+    if (buffer == null)
+      throw new ArgumentNullException(nameof(buffer));
+    if (count < 0)
+      throw ExceptionUtils.CreateArgumentMustBeZeroOrPositive(nameof(count), count);
+    if (offset < 0)
+      throw ExceptionUtils.CreateArgumentMustBeZeroOrPositive(nameof(offset), offset);
+    if (buffer.Length < count + offset)
+      throw ExceptionUtils.CreateArgumentAttemptToAccessBeyondEndOfArray(nameof(offset), buffer, offset, count);
+
+    if (cancellationToken.IsCancellationRequested)
 #if SYSTEM_THREADING_TASKS_TASK_FROMCANCELED
-        return Task.FromCanceled<int>(cancellationToken);
+      return Task.FromCanceled<int>(cancellationToken);
+#else
+      return new Task<int>(() => default, cancellationToken);
+#endif
+    if (count == 0)
+      return Task.FromResult(count);
+
+    return ReadAsyncUnchecked(
+      buffer.AsMemory(offset, count),
+      cancellationToken
+#if SYSTEM_THREADING_TASKS_VALUETASK
+    ).AsTask();
 #else
-        return new Task<int>(() => default, cancellationToken);
+    );
 #endif
-      if (count == 0)
-        return Task.FromResult(count);
+  }
 
-      return ReadAsyncUnchecked(buffer, offset, count, cancellationToken);
-    }
+#if SYSTEM_IO_STREAM_READASYNC_MEMORY_OF_BYTE
+  public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+  {
+    ThrowIfDisposed();
 
-    protected virtual Task<int> ReadAsyncUnchecked(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-    {
-      var dest = buffer.AsMemory(offset, count);
+    if (cancellationToken.IsCancellationRequested)
+#if SYSTEM_THREADING_TASKS_VALUETASK_FROMCANCELED
+      return ValueTask.FromCanceled<int>(cancellationToken);
+#else
+#if SYSTEM_THREADING_TASKS_TASK_FROMCANCELED
+      return new(Task.FromCanceled<int>(cancellationToken));
+#else
+      return new(new Task<int>(() => default, cancellationToken));
+#endif
+#endif
 
-      if (dest.Length <= bufferReadCursor.Length)
-        return Task.FromResult(ReadBuffer(ref dest));
+    if (buffer.IsEmpty)
+      return new(0); // do nothing
 
-      return ReadAsyncCore();
+    return ReadAsyncUnchecked(buffer, cancellationToken);
+  }
+#endif
 
-      async Task<int> ReadAsyncCore()
-      {
-        var read = 0;
+  [Obsolete("use Memory<byte> version instead")]
+  protected virtual Task<int> ReadAsyncUnchecked(
+    byte[] buffer,
+    int offset,
+    int count,
+    CancellationToken cancellationToken
+  )
+    => ReadAsyncUnchecked(
+      (buffer ?? throw new ArgumentNullException(nameof(buffer))).AsMemory(offset, count),
+      cancellationToken
+#if SYSTEM_THREADING_TASKS_VALUETASK
+    ).AsTask();
+#else
+    );
+#endif
 
-        for (; ; ) {
-          if (bufferReadCursor.Length == 0) {
-            if (hasReachedEndOfStream)
-              return read;
+  protected virtual
+#if SYSTEM_THREADING_TASKS_VALUETASK
+  ValueTask<int>
+#else
+  Task<int>
+#endif
+  ReadAsyncUnchecked(
+    Memory<byte> destination,
+    CancellationToken cancellationToken
+  )
+  {
+    if (destination.Length <= bufferReadCursor.Length)
+#if SYSTEM_THREADING_TASKS_VALUETASK
+      return new(ReadBuffer(ref destination));
+#else
+      return Task.FromResult(ReadBuffer(ref destination));
+#endif
 
-            await FillBufferAsync(cancellationToken).ConfigureAwait(false);
-          }
+    return ReadAsyncCore();
 
-          read += ReadBuffer(ref dest);
+    async
+#if SYSTEM_THREADING_TASKS_VALUETASK
+    ValueTask<int>
+#else
+    Task<int>
+#endif
+    ReadAsyncCore()
+    {
+      var read = 0;
 
-          if (dest.Length == 0)
+      for (; ; ) {
+        if (bufferReadCursor.Length == 0) {
+          if (hasReachedEndOfStream)
             return read;
+
+          await FillBufferAsync(cancellationToken).ConfigureAwait(false);
         }
+
+        read += ReadBuffer(ref destination);
+
+        if (destination.IsEmpty)
+          return read;
       }
     }
+  }
 
-    private byte[] rawBuffer;
-    private ReadOnlyMemory<byte> bufferReadCursor = ReadOnlyMemory<byte>.Empty;
-    private long offset;
-    private bool hasReachedEndOfStream;
-
-    private int ReadBuffer(ref Memory<byte> dest)
-    {
-      var count = Math.Min(dest.Length, bufferReadCursor.Length);
+  private readonly byte[] rawBuffer;
+  private ReadOnlyMemory<byte> bufferReadCursor = ReadOnlyMemory<byte>.Empty;
+  private long offset;
+  private bool hasReachedEndOfStream;
 
-      bufferReadCursor.Slice(0, count).CopyTo(dest);
-      offset += count;
+  private int ReadBuffer(ref Memory<byte> dest)
+  {
+    var count = Math.Min(dest.Length, bufferReadCursor.Length);
 
-      dest = dest.Slice(count);
-      bufferReadCursor = bufferReadCursor.Slice(count);
+    bufferReadCursor.Slice(0, count).CopyTo(dest);
+    offset += count;
 
-      return count;
-    }
+    dest = dest.Slice(count);
+    bufferReadCursor = bufferReadCursor.Slice(count);
 
-    private long AdvanceBufferTo(long newOffset)
-    {
-      var advance = newOffset - offset;
+    return count;
+  }
 
-      if (0 <= advance && advance < bufferReadCursor.Length)
-        bufferReadCursor = bufferReadCursor.Slice((int)advance); // advance read cursor
-      else
-        bufferReadCursor = ReadOnlyMemory<byte>.Empty; // discard read cursor
+  private long AdvanceBufferTo(long newOffset)
+  {
+    var advance = newOffset - offset;
 
-      offset = newOffset;
-      hasReachedEndOfStream = false;
+    if (0 <= advance && advance < bufferReadCursor.Length)
+      bufferReadCursor = bufferReadCursor.Slice((int)advance); // advance read cursor
+    else
+      bufferReadCursor = ReadOnlyMemory<byte>.Empty; // discard read cursor
 
-      return offset;
-    }
+    offset = newOffset;
+    hasReachedEndOfStream = false;
 
-    private void FillBuffer()
-    {
-      var read = stream.Read(rawBuffer, 0, rawBuffer.Length);
+    return offset;
+  }
 
-      hasReachedEndOfStream |= read < rawBuffer.Length;
+  private void FillBuffer()
+  {
+    var read = stream.Read(rawBuffer, 0, rawBuffer.Length);
 
-      bufferReadCursor = FilterBuffer(rawBuffer.AsMemory(0, read));
-    }
+    hasReachedEndOfStream |= read < rawBuffer.Length;
 
-    private async Task FillBufferAsync(CancellationToken cancellationToken)
-    {
-      var read = await stream.ReadAsync(rawBuffer, 0, rawBuffer.Length, cancellationToken).ConfigureAwait(false);
+    bufferReadCursor = FilterBuffer(rawBuffer.AsMemory(0, read));
+  }
 
-      hasReachedEndOfStream |= read < rawBuffer.Length;
+  private async Task FillBufferAsync(CancellationToken cancellationToken)
+  {
+    var read =
+#if SYSTEM_IO_STREAM_READASYNC_MEMORY_OF_BYTE
+      await stream.ReadAsync(
+        rawBuffer.AsMemory(),
+#else
+      await stream.ReadAsync(
+        rawBuffer,
+        0,
+        rawBuffer.Length,
+#endif
+        cancellationToken
+      ).ConfigureAwait(false);
 
-      bufferReadCursor = FilterBuffer(rawBuffer.AsMemory(0, read));
-    }
+    hasReachedEndOfStream |= read < rawBuffer.Length;
 
-    private Memory<byte> FilterBuffer(Memory<byte> buffer)
-    {
-      foreach (var filter in Filters) {
-        if (filter.Offset + filter.Length < offset)
-          continue;
-        if (offset + buffer.Length < filter.Offset)
-          continue;
+    bufferReadCursor = FilterBuffer(rawBuffer.AsMemory(0, read));
+  }
 
-        var relativeOffset = filter.Offset - offset;
-        var length = relativeOffset < 0L ? filter.Length + relativeOffset : filter.Length;
+  private Memory<byte> FilterBuffer(Memory<byte> buffer)
+  {
+    foreach (var filter in Filters) {
+      if (filter.Offset + filter.Length < offset)
+        continue;
+      if (offset + buffer.Length < filter.Offset)
+        continue;
 
-        if (length == 0L)
-          continue;
+      var relativeOffset = filter.Offset - offset;
+      var length = relativeOffset < 0L ? filter.Length + relativeOffset : filter.Length;
 
-        var span = buffer.Span.Slice(Math.Max(0, (int)relativeOffset));
+      if (length == 0L)
+        continue;
 
-        if (length < span.Length)
-          span = span.Slice(0, (int)length);
+      var span = buffer.Span.Slice(Math.Max(0, (int)relativeOffset));
 
-        filter.Apply(span, Math.Max(0, -relativeOffset));
-      }
+      if (length < span.Length)
+        span = span.Slice(0, (int)length);
 
-      return buffer;
+      filter.Apply(span, Math.Max(0, -relativeOffset));
     }
+
+    return buffer;
   }
 }
```

</div>
</details>


