### PR TITLE
Release main/Smdn.Fundamental.Encoding-3.0.1.1

### DIFF
--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-net45.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.1)
+// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.1.1)
 //   Name: Smdn.Fundamental.Encoding
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1+403df09df7ef4576307947fac83e89eb7693a163
+//   AssemblyVersion: 3.0.1.1
+//   InformationalVersion: 3.0.1.1+a0f6e52cd3b31755404137f392bf6c953a4d28db
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 

--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.0.apilist.cs
@@ -2,10 +2,11 @@
 //   Name: Smdn.Fundamental.Encoding
 //   AssemblyVersion: 3.0.1.1
 //   InformationalVersion: 3.0.1.1+a0f6e52cd3b31755404137f392bf6c953a4d28db
-//   TargetFramework: .NETStandard,Version=v1.6
+//   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 
 using System;
+using System.Runtime.Serialization;
 using System.Text;
 using Smdn.Text.Encodings;
 
@@ -16,6 +17,7 @@ namespace Smdn.Text.Encodings {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [Serializable]
   public class EncodingNotSupportedException : NotSupportedException {
+    protected EncodingNotSupportedException(SerializationInfo info, StreamingContext context) {}
     public EncodingNotSupportedException() {}
     public EncodingNotSupportedException(string encodingName) {}
     public EncodingNotSupportedException(string encodingName, Exception innerException) {}
@@ -23,6 +25,8 @@ namespace Smdn.Text.Encodings {
     public EncodingNotSupportedException(string encodingName, string message, Exception innerException) {}
 
     public string EncodingName { get; }
+
+    public override void GetObjectData(SerializationInfo info, StreamingContext context) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]

--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.1)
+// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.1.1)
 //   Name: Smdn.Fundamental.Encoding
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1+403df09df7ef4576307947fac83e89eb7693a163
+//   AssemblyVersion: 3.0.1.1
+//   InformationalVersion: 3.0.1.1+a0f6e52cd3b31755404137f392bf6c953a4d28db
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #51](https://github.com/smdn/Smdn.Fundamentals/actions/runs/1922712127).

# Release target
- package_target_tag: `new-release/main/Smdn.Fundamental.Encoding-3.0.1.1`
- package_id: `Smdn.Fundamental.Encoding`
- package_id_with_version: `Smdn.Fundamental.Encoding-3.0.1.1`
- package_version: `3.0.1.1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.Encoding-3.0.1.1-1646230816`
- release_tag: `releases/Smdn.Fundamental.Encoding-3.0.1.1`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- release_note_url: [`https://gist.github.com/efb97bc180db0191771b45431807e052`](https://gist.github.com/efb97bc180db0191771b45431807e052)
- artifact_name_nupkg: `Smdn.Fundamental.Encoding.3.0.1.1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec
```nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.Encoding</id>
    <version>3.0.1.1</version>
    <title>Smdn.Fundamental.Encoding</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.Encoding.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.Encoding.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp encoding extensions</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="a0f6e52cd3b31755404137f392bf6c953a4d28db" />
    <dependencies>
      <group targetFramework=".NETFramework4.5" />
      <group targetFramework=".NETStandard1.6">
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Runtime.Serialization.Formatters" version="4.3.0" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.0" />
      <group targetFramework=".NETStandard2.1" />
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/net45/Smdn.Fundamental.Encoding.dll" target="lib/net45/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/netstandard1.6/Smdn.Fundamental.Encoding.dll" target="lib/netstandard1.6/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/netstandard2.0/Smdn.Fundamental.Encoding.dll" target="lib/netstandard2.0/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/netstandard2.1/Smdn.Fundamental.Encoding.dll" target="lib/netstandard2.1/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/.nuget/packages/smdn.msbuild.projectassets.common/1.1.0/project/images/package-icon.png" target="Smdn.Fundamental.Encoding.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

