### PR TITLE
Release main/Smdn.Fundamental.Encoding.OctetEncoding-3.0.1

### DIFF
--- a/doc/api-list/Smdn.Fundamental.Encoding.OctetEncoding/Smdn.Fundamental.Encoding.OctetEncoding-net46.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding.OctetEncoding/Smdn.Fundamental.Encoding.OctetEncoding-net46.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.Encoding.OctetEncoding
 //   AssemblyVersion: 3.0.1.0
 //   InformationalVersion: 3.0.1+a8efaa66645cdba0dfd996d21cad4994bb5fd86b
-//   TargetFramework: .NETFramework,Version=v4.5
+//   TargetFramework: .NETFramework,Version=v4.6
 //   Configuration: Release
 
 using System.Text;
@@ -14,6 +14,7 @@ namespace Smdn.Text.Encodings {
     public static readonly Encoding SevenBits; // = "Smdn.Text.Encodings.OctetEncoding"
 
     public OctetEncoding(int bits) {}
+    public OctetEncoding(int bits, EncoderFallback encoderFallback, DecoderFallback decoderFallback) {}
 
     public override int GetByteCount(char[] chars, int index, int count) {}
     public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) {}

--- a/doc/api-list/Smdn.Fundamental.Encoding.OctetEncoding/Smdn.Fundamental.Encoding.OctetEncoding-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding.OctetEncoding/Smdn.Fundamental.Encoding.OctetEncoding-net6.0.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.Encoding.OctetEncoding
 //   AssemblyVersion: 3.0.1.0
 //   InformationalVersion: 3.0.1+a8efaa66645cdba0dfd996d21cad4994bb5fd86b
-//   TargetFramework: .NETFramework,Version=v4.5
+//   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 
 using System.Text;
@@ -14,6 +14,7 @@ namespace Smdn.Text.Encodings {
     public static readonly Encoding SevenBits; // = "Smdn.Text.Encodings.OctetEncoding"
 
     public OctetEncoding(int bits) {}
+    public OctetEncoding(int bits, EncoderFallback encoderFallback, DecoderFallback decoderFallback) {}
 
     public override int GetByteCount(char[] chars, int index, int count) {}
     public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) {}

--- a/doc/api-list/Smdn.Fundamental.Encoding.OctetEncoding/Smdn.Fundamental.Encoding.OctetEncoding-netstandard1.3.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding.OctetEncoding/Smdn.Fundamental.Encoding.OctetEncoding-netstandard1.3.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.Encoding.OctetEncoding
 //   AssemblyVersion: 3.0.1.0
 //   InformationalVersion: 3.0.1+a8efaa66645cdba0dfd996d21cad4994bb5fd86b
-//   TargetFramework: .NETFramework,Version=v4.5
+//   TargetFramework: .NETStandard,Version=v1.3
 //   Configuration: Release
 
 using System.Text;
@@ -14,6 +14,7 @@ namespace Smdn.Text.Encodings {
     public static readonly Encoding SevenBits; // = "Smdn.Text.Encodings.OctetEncoding"
 
     public OctetEncoding(int bits) {}
+    public OctetEncoding(int bits, EncoderFallback encoderFallback, DecoderFallback decoderFallback) {}
 
     public override int GetByteCount(char[] chars, int index, int count) {}
     public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) {}

--- a/doc/api-list/Smdn.Fundamental.Encoding.OctetEncoding/Smdn.Fundamental.Encoding.OctetEncoding-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding.OctetEncoding/Smdn.Fundamental.Encoding.OctetEncoding-netstandard1.6.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Encoding.OctetEncoding.dll (Smdn.Fundamental.Encoding.OctetEncoding-3.0.0 (netstandard1.6))
+// Smdn.Fundamental.Encoding.OctetEncoding.dll (Smdn.Fundamental.Encoding.OctetEncoding-3.0.1)
 //   Name: Smdn.Fundamental.Encoding.OctetEncoding
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (netstandard1.6)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+a8efaa66645cdba0dfd996d21cad4994bb5fd86b
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 

--- a/doc/api-list/Smdn.Fundamental.Encoding.OctetEncoding/Smdn.Fundamental.Encoding.OctetEncoding-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding.OctetEncoding/Smdn.Fundamental.Encoding.OctetEncoding-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Encoding.OctetEncoding.dll (Smdn.Fundamental.Encoding.OctetEncoding-3.0.0 (netstandard2.1))
+// Smdn.Fundamental.Encoding.OctetEncoding.dll (Smdn.Fundamental.Encoding.OctetEncoding-3.0.1)
 //   Name: Smdn.Fundamental.Encoding.OctetEncoding
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (netstandard2.1)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+a8efaa66645cdba0dfd996d21cad4994bb5fd86b
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #94](https://github.com/smdn/Smdn.Fundamentals/actions/runs/2265332471).

# Release target
- package_target_tag: `new-release/main/Smdn.Fundamental.Encoding.OctetEncoding-3.0.1`
- package_id: `Smdn.Fundamental.Encoding.OctetEncoding`
- package_id_with_version: `Smdn.Fundamental.Encoding.OctetEncoding-3.0.1`
- package_version: `3.0.1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.Encoding.OctetEncoding-3.0.1-1651598948`
- release_tag: `releases/Smdn.Fundamental.Encoding.OctetEncoding-3.0.1`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- release_note_url: [`https://gist.github.com/55b4ad107099694288b167c9c2e0a1b3`](https://gist.github.com/55b4ad107099694288b167c9c2e0a1b3)
- artifact_name_nupkg: `Smdn.Fundamental.Encoding.OctetEncoding.3.0.1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec
```nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.Encoding.OctetEncoding</id>
    <version>3.0.1</version>
    <title>Smdn.Fundamental.Encoding.OctetEncoding</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.Encoding.OctetEncoding.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.Encoding.OctetEncoding.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp ascii-8bit ascii-7bit encoding</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="a8efaa66645cdba0dfd996d21cad4994bb5fd86b" />
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETFramework4.6">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.3">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework="net6.0">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.1">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.0, 4.0.0)" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding.OctetEncoding/bin/Release/net45/Smdn.Fundamental.Encoding.OctetEncoding.dll" target="lib/net45/Smdn.Fundamental.Encoding.OctetEncoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding.OctetEncoding/bin/Release/net46/Smdn.Fundamental.Encoding.OctetEncoding.dll" target="lib/net46/Smdn.Fundamental.Encoding.OctetEncoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding.OctetEncoding/bin/Release/net6.0/Smdn.Fundamental.Encoding.OctetEncoding.dll" target="lib/net6.0/Smdn.Fundamental.Encoding.OctetEncoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding.OctetEncoding/bin/Release/netstandard1.3/Smdn.Fundamental.Encoding.OctetEncoding.dll" target="lib/netstandard1.3/Smdn.Fundamental.Encoding.OctetEncoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding.OctetEncoding/bin/Release/netstandard1.6/Smdn.Fundamental.Encoding.OctetEncoding.dll" target="lib/netstandard1.6/Smdn.Fundamental.Encoding.OctetEncoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding.OctetEncoding/bin/Release/netstandard2.1/Smdn.Fundamental.Encoding.OctetEncoding.dll" target="lib/netstandard2.1/Smdn.Fundamental.Encoding.OctetEncoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.1.1/project/images/package-icon.png" target="Smdn.Fundamental.Encoding.OctetEncoding.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding.OctetEncoding/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

