### PR TITLE
Release main/Smdn.Fundamental.StandardDateTimeFormat-3.1.0

### DIFF
--- a/doc/api-list/Smdn.Fundamental.StandardDateTimeFormat/Smdn.Fundamental.StandardDateTimeFormat-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.StandardDateTimeFormat/Smdn.Fundamental.StandardDateTimeFormat-net45.apilist.cs
@@ -1,21 +1,25 @@
-// Smdn.Fundamental.StandardDateTimeFormat.dll (Smdn.Fundamental.StandardDateTimeFormat-3.0.0 (net45))
+// Smdn.Fundamental.StandardDateTimeFormat.dll (Smdn.Fundamental.StandardDateTimeFormat-3.1.0)
 //   Name: Smdn.Fundamental.StandardDateTimeFormat
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (net45)
+//   AssemblyVersion: 3.1.0.0
+//   InformationalVersion: 3.1.0+e70d21c3633ec38bff9bacbccb59b3fb48138896
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 
 using System;
 
 namespace Smdn.Formats {
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class DateTimeFormat {
     public static DateTimeOffset FromISO8601DateTimeOffsetString(string s) {}
     public static DateTime FromISO8601DateTimeString(string s) {}
     public static DateTimeOffset FromRFC822DateTimeOffsetString(string s) {}
+    [NullableContext(2)]
     public static DateTimeOffset? FromRFC822DateTimeOffsetStringNullable(string s) {}
     public static DateTime FromRFC822DateTimeString(string s) {}
     public static DateTimeOffset FromW3CDateTimeOffsetString(string s) {}
+    [NullableContext(2)]
     public static DateTimeOffset? FromW3CDateTimeOffsetStringNullable(string s) {}
     public static DateTime FromW3CDateTimeString(string s) {}
     public static string GetCurrentTimeZoneOffsetString(bool delimiter) {}
@@ -23,10 +27,72 @@ namespace Smdn.Formats {
     public static string ToISO8601DateTimeString(DateTimeOffset dateTimeOffset) {}
     public static string ToRFC822DateTimeString(DateTime dateTime) {}
     public static string ToRFC822DateTimeString(DateTimeOffset dateTimeOffset) {}
+    [NullableContext(2)]
     public static string ToRFC822DateTimeStringNullable(DateTimeOffset? dateTimeOffset) {}
     public static string ToW3CDateTimeString(DateTime dateTime) {}
     public static string ToW3CDateTimeString(DateTimeOffset dateTimeOffset) {}
+    [NullableContext(2)]
     public static string ToW3CDateTimeStringNullable(DateTimeOffset? dateTimeOffset) {}
+  }
+}
+
+namespace Smdn.Formats.DateAndTime {
+  public static class DateAndTimeFormatter {
+    [NullableContext(1)]
+    public static string FormatOffset(TimeSpan offset, bool delimiter) {}
+  }
+
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
+  public static class ISO8601DateTimeFormats {
+    [NullableContext(byte.MinValue)]
+    public static DateTime ParseDateTime(ReadOnlySpan<char> s) {}
+    public static DateTime ParseDateTime(string s) {}
+    [NullableContext(byte.MinValue)]
+    public static DateTimeOffset ParseDateTimeOffset(ReadOnlySpan<char> s) {}
+    public static DateTimeOffset ParseDateTimeOffset(string s) {}
+    [NullableContext(byte.MinValue)]
+    public static bool TryParseDateTime(ReadOnlySpan<char> s, out DateTime result) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTime(string s, out DateTime result) {}
+    [NullableContext(byte.MinValue)]
+    public static bool TryParseDateTimeOffset(ReadOnlySpan<char> s, out DateTimeOffset result) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTimeOffset(string s, out DateTimeOffset result) {}
+  }
+
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
+  public static class RFC822DateTimeFormats {
+    [NullableContext(byte.MinValue)]
+    public static DateTime ParseDateTime(ReadOnlySpan<char> s) {}
+    public static DateTime ParseDateTime(string s) {}
+    [NullableContext(byte.MinValue)]
+    public static DateTimeOffset ParseDateTimeOffset(ReadOnlySpan<char> s) {}
+    public static DateTimeOffset ParseDateTimeOffset(string s) {}
+    [NullableContext(byte.MinValue)]
+    public static bool TryParseDateTime(ReadOnlySpan<char> s, out DateTime result) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTime(string s, out DateTime result) {}
+    [NullableContext(byte.MinValue)]
+    public static bool TryParseDateTimeOffset(ReadOnlySpan<char> s, out DateTimeOffset result) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTimeOffset(string s, out DateTimeOffset result) {}
+  }
+
+  public static class W3CDateTimeFormats {
+    public static DateTime ParseDateTime(ReadOnlySpan<char> s) {}
+    [NullableContext(1)]
+    public static DateTime ParseDateTime(string s) {}
+    public static DateTimeOffset ParseDateTimeOffset(ReadOnlySpan<char> s) {}
+    [NullableContext(1)]
+    public static DateTimeOffset ParseDateTimeOffset(string s) {}
+    public static bool TryParseDateTime(ReadOnlySpan<char> s, out DateTime result) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTime(string s, out DateTime result) {}
+    public static bool TryParseDateTimeOffset(ReadOnlySpan<char> s, out DateTimeOffset result) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTimeOffset(string s, out DateTimeOffset result) {}
   }
 }
 

--- a/doc/api-list/Smdn.Fundamental.StandardDateTimeFormat/Smdn.Fundamental.StandardDateTimeFormat-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.StandardDateTimeFormat/Smdn.Fundamental.StandardDateTimeFormat-net6.0.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.StandardDateTimeFormat
 //   AssemblyVersion: 3.1.0.0
 //   InformationalVersion: 3.1.0+e70d21c3633ec38bff9bacbccb59b3fb48138896
-//   TargetFramework: .NETStandard,Version=v1.6
+//   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 
 using System;
@@ -51,6 +51,9 @@ namespace Smdn.Formats.DateAndTime {
     [NullableContext(byte.MinValue)]
     public static DateTimeOffset ParseDateTimeOffset(ReadOnlySpan<char> s) {}
     public static DateTimeOffset ParseDateTimeOffset(string s) {}
+    public static string ToWeekDateString(DateOnly date) {}
+    public static string ToWeekDateString(DateTime date) {}
+    public static string ToWeekDateString(DateTimeOffset date) {}
     [NullableContext(byte.MinValue)]
     public static bool TryParseDateTime(ReadOnlySpan<char> s, out DateTime result) {}
     [NullableContext(2)]

--- a/doc/api-list/Smdn.Fundamental.StandardDateTimeFormat/Smdn.Fundamental.StandardDateTimeFormat-netstandard1.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.StandardDateTimeFormat/Smdn.Fundamental.StandardDateTimeFormat-netstandard1.0.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.StandardDateTimeFormat
 //   AssemblyVersion: 3.1.0.0
 //   InformationalVersion: 3.1.0+e70d21c3633ec38bff9bacbccb59b3fb48138896
-//   TargetFramework: .NETStandard,Version=v1.6
+//   TargetFramework: .NETStandard,Version=v1.0
 //   Configuration: Release
 
 using System;
@@ -45,52 +45,32 @@ namespace Smdn.Formats.DateAndTime {
   [Nullable(byte.MinValue)]
   [NullableContext(1)]
   public static class ISO8601DateTimeFormats {
-    [NullableContext(byte.MinValue)]
-    public static DateTime ParseDateTime(ReadOnlySpan<char> s) {}
     public static DateTime ParseDateTime(string s) {}
-    [NullableContext(byte.MinValue)]
-    public static DateTimeOffset ParseDateTimeOffset(ReadOnlySpan<char> s) {}
     public static DateTimeOffset ParseDateTimeOffset(string s) {}
-    [NullableContext(byte.MinValue)]
-    public static bool TryParseDateTime(ReadOnlySpan<char> s, out DateTime result) {}
     [NullableContext(2)]
     public static bool TryParseDateTime(string s, out DateTime result) {}
-    [NullableContext(byte.MinValue)]
-    public static bool TryParseDateTimeOffset(ReadOnlySpan<char> s, out DateTimeOffset result) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTimeOffset(string s, out DateTimeOffset result) {}
+  }
+
+  public static class RFC822DateTimeFormats {
+    [NullableContext(1)]
+    public static DateTime ParseDateTime(string s) {}
+    [NullableContext(1)]
+    public static DateTimeOffset ParseDateTimeOffset(string s) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTime(string s, out DateTime result) {}
     [NullableContext(2)]
     public static bool TryParseDateTimeOffset(string s, out DateTimeOffset result) {}
   }
 
   [Nullable(byte.MinValue)]
   [NullableContext(1)]
-  public static class RFC822DateTimeFormats {
-    [NullableContext(byte.MinValue)]
-    public static DateTime ParseDateTime(ReadOnlySpan<char> s) {}
-    public static DateTime ParseDateTime(string s) {}
-    [NullableContext(byte.MinValue)]
-    public static DateTimeOffset ParseDateTimeOffset(ReadOnlySpan<char> s) {}
-    public static DateTimeOffset ParseDateTimeOffset(string s) {}
-    [NullableContext(byte.MinValue)]
-    public static bool TryParseDateTime(ReadOnlySpan<char> s, out DateTime result) {}
-    [NullableContext(2)]
-    public static bool TryParseDateTime(string s, out DateTime result) {}
-    [NullableContext(byte.MinValue)]
-    public static bool TryParseDateTimeOffset(ReadOnlySpan<char> s, out DateTimeOffset result) {}
-    [NullableContext(2)]
-    public static bool TryParseDateTimeOffset(string s, out DateTimeOffset result) {}
-  }
-
   public static class W3CDateTimeFormats {
-    public static DateTime ParseDateTime(ReadOnlySpan<char> s) {}
-    [NullableContext(1)]
     public static DateTime ParseDateTime(string s) {}
-    public static DateTimeOffset ParseDateTimeOffset(ReadOnlySpan<char> s) {}
-    [NullableContext(1)]
     public static DateTimeOffset ParseDateTimeOffset(string s) {}
-    public static bool TryParseDateTime(ReadOnlySpan<char> s, out DateTime result) {}
     [NullableContext(2)]
     public static bool TryParseDateTime(string s, out DateTime result) {}
-    public static bool TryParseDateTimeOffset(ReadOnlySpan<char> s, out DateTimeOffset result) {}
     [NullableContext(2)]
     public static bool TryParseDateTimeOffset(string s, out DateTimeOffset result) {}
   }

--- a/doc/api-list/Smdn.Fundamental.StandardDateTimeFormat/Smdn.Fundamental.StandardDateTimeFormat-netstandard1.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.StandardDateTimeFormat/Smdn.Fundamental.StandardDateTimeFormat-netstandard1.1.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.StandardDateTimeFormat
 //   AssemblyVersion: 3.1.0.0
 //   InformationalVersion: 3.1.0+e70d21c3633ec38bff9bacbccb59b3fb48138896
-//   TargetFramework: .NETStandard,Version=v1.6
+//   TargetFramework: .NETStandard,Version=v1.1
 //   Configuration: Release
 
 using System;
@@ -61,20 +61,16 @@ namespace Smdn.Formats.DateAndTime {
     public static bool TryParseDateTimeOffset(string s, out DateTimeOffset result) {}
   }
 
-  [Nullable(byte.MinValue)]
-  [NullableContext(1)]
   public static class RFC822DateTimeFormats {
-    [NullableContext(byte.MinValue)]
     public static DateTime ParseDateTime(ReadOnlySpan<char> s) {}
+    [NullableContext(1)]
     public static DateTime ParseDateTime(string s) {}
-    [NullableContext(byte.MinValue)]
     public static DateTimeOffset ParseDateTimeOffset(ReadOnlySpan<char> s) {}
+    [NullableContext(1)]
     public static DateTimeOffset ParseDateTimeOffset(string s) {}
-    [NullableContext(byte.MinValue)]
     public static bool TryParseDateTime(ReadOnlySpan<char> s, out DateTime result) {}
     [NullableContext(2)]
     public static bool TryParseDateTime(string s, out DateTime result) {}
-    [NullableContext(byte.MinValue)]
     public static bool TryParseDateTimeOffset(ReadOnlySpan<char> s, out DateTimeOffset result) {}
     [NullableContext(2)]
     public static bool TryParseDateTimeOffset(string s, out DateTimeOffset result) {}

--- a/doc/api-list/Smdn.Fundamental.StandardDateTimeFormat/Smdn.Fundamental.StandardDateTimeFormat-netstandard1.3.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.StandardDateTimeFormat/Smdn.Fundamental.StandardDateTimeFormat-netstandard1.3.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.StandardDateTimeFormat
 //   AssemblyVersion: 3.1.0.0
 //   InformationalVersion: 3.1.0+e70d21c3633ec38bff9bacbccb59b3fb48138896
-//   TargetFramework: .NETStandard,Version=v1.6
+//   TargetFramework: .NETStandard,Version=v1.3
 //   Configuration: Release
 
 using System;

--- a/doc/api-list/Smdn.Fundamental.StandardDateTimeFormat/Smdn.Fundamental.StandardDateTimeFormat-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.StandardDateTimeFormat/Smdn.Fundamental.StandardDateTimeFormat-netstandard2.1.apilist.cs
@@ -1,21 +1,25 @@
-// Smdn.Fundamental.StandardDateTimeFormat.dll (Smdn.Fundamental.StandardDateTimeFormat-3.0.0 (netstandard2.1))
+// Smdn.Fundamental.StandardDateTimeFormat.dll (Smdn.Fundamental.StandardDateTimeFormat-3.1.0)
 //   Name: Smdn.Fundamental.StandardDateTimeFormat
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (netstandard2.1)
+//   AssemblyVersion: 3.1.0.0
+//   InformationalVersion: 3.1.0+e70d21c3633ec38bff9bacbccb59b3fb48138896
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
 using System;
 
 namespace Smdn.Formats {
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class DateTimeFormat {
     public static DateTimeOffset FromISO8601DateTimeOffsetString(string s) {}
     public static DateTime FromISO8601DateTimeString(string s) {}
     public static DateTimeOffset FromRFC822DateTimeOffsetString(string s) {}
+    [NullableContext(2)]
     public static DateTimeOffset? FromRFC822DateTimeOffsetStringNullable(string s) {}
     public static DateTime FromRFC822DateTimeString(string s) {}
     public static DateTimeOffset FromW3CDateTimeOffsetString(string s) {}
+    [NullableContext(2)]
     public static DateTimeOffset? FromW3CDateTimeOffsetStringNullable(string s) {}
     public static DateTime FromW3CDateTimeString(string s) {}
     public static string GetCurrentTimeZoneOffsetString(bool delimiter) {}
@@ -23,10 +27,74 @@ namespace Smdn.Formats {
     public static string ToISO8601DateTimeString(DateTimeOffset dateTimeOffset) {}
     public static string ToRFC822DateTimeString(DateTime dateTime) {}
     public static string ToRFC822DateTimeString(DateTimeOffset dateTimeOffset) {}
+    [NullableContext(2)]
     public static string ToRFC822DateTimeStringNullable(DateTimeOffset? dateTimeOffset) {}
     public static string ToW3CDateTimeString(DateTime dateTime) {}
     public static string ToW3CDateTimeString(DateTimeOffset dateTimeOffset) {}
+    [NullableContext(2)]
     public static string ToW3CDateTimeStringNullable(DateTimeOffset? dateTimeOffset) {}
+  }
+}
+
+namespace Smdn.Formats.DateAndTime {
+  public static class DateAndTimeFormatter {
+    [NullableContext(1)]
+    public static string FormatOffset(TimeSpan offset, bool delimiter) {}
+  }
+
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
+  public static class ISO8601DateTimeFormats {
+    [NullableContext(byte.MinValue)]
+    public static DateTime ParseDateTime(ReadOnlySpan<char> s) {}
+    public static DateTime ParseDateTime(string s) {}
+    [NullableContext(byte.MinValue)]
+    public static DateTimeOffset ParseDateTimeOffset(ReadOnlySpan<char> s) {}
+    public static DateTimeOffset ParseDateTimeOffset(string s) {}
+    public static string ToWeekDateString(DateTime date) {}
+    public static string ToWeekDateString(DateTimeOffset date) {}
+    [NullableContext(byte.MinValue)]
+    public static bool TryParseDateTime(ReadOnlySpan<char> s, out DateTime result) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTime(string s, out DateTime result) {}
+    [NullableContext(byte.MinValue)]
+    public static bool TryParseDateTimeOffset(ReadOnlySpan<char> s, out DateTimeOffset result) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTimeOffset(string s, out DateTimeOffset result) {}
+  }
+
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
+  public static class RFC822DateTimeFormats {
+    [NullableContext(byte.MinValue)]
+    public static DateTime ParseDateTime(ReadOnlySpan<char> s) {}
+    public static DateTime ParseDateTime(string s) {}
+    [NullableContext(byte.MinValue)]
+    public static DateTimeOffset ParseDateTimeOffset(ReadOnlySpan<char> s) {}
+    public static DateTimeOffset ParseDateTimeOffset(string s) {}
+    [NullableContext(byte.MinValue)]
+    public static bool TryParseDateTime(ReadOnlySpan<char> s, out DateTime result) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTime(string s, out DateTime result) {}
+    [NullableContext(byte.MinValue)]
+    public static bool TryParseDateTimeOffset(ReadOnlySpan<char> s, out DateTimeOffset result) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTimeOffset(string s, out DateTimeOffset result) {}
+  }
+
+  public static class W3CDateTimeFormats {
+    public static DateTime ParseDateTime(ReadOnlySpan<char> s) {}
+    [NullableContext(1)]
+    public static DateTime ParseDateTime(string s) {}
+    public static DateTimeOffset ParseDateTimeOffset(ReadOnlySpan<char> s) {}
+    [NullableContext(1)]
+    public static DateTimeOffset ParseDateTimeOffset(string s) {}
+    public static bool TryParseDateTime(ReadOnlySpan<char> s, out DateTime result) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTime(string s, out DateTime result) {}
+    public static bool TryParseDateTimeOffset(ReadOnlySpan<char> s, out DateTimeOffset result) {}
+    [NullableContext(2)]
+    public static bool TryParseDateTimeOffset(string s, out DateTimeOffset result) {}
   }
 }
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #95](https://github.com/smdn/Smdn.Fundamentals/actions/runs/2265363223).

# Release target
- package_target_tag: `new-release/main/Smdn.Fundamental.StandardDateTimeFormat-3.1.0`
- package_id: `Smdn.Fundamental.StandardDateTimeFormat`
- package_id_with_version: `Smdn.Fundamental.StandardDateTimeFormat-3.1.0`
- package_version: `3.1.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.StandardDateTimeFormat-3.1.0-1651600684`
- release_tag: `releases/Smdn.Fundamental.StandardDateTimeFormat-3.1.0`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- release_note_url: [`https://gist.github.com/9dc8c4d39593d0a975e3a93b162de355`](https://gist.github.com/9dc8c4d39593d0a975e3a93b162de355)
- artifact_name_nupkg: `Smdn.Fundamental.StandardDateTimeFormat.3.1.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec
```nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.StandardDateTimeFormat</id>
    <version>3.1.0</version>
    <title>Smdn.Fundamental.StandardDateTimeFormat</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.StandardDateTimeFormat.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.StandardDateTimeFormat.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp datetime date-and-time format RFC822 RFC2822 RFC5322 ISO8601 extensions</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="e70d21c3633ec38bff9bacbccb59b3fb48138896" />
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.0">
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.1">
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.3">
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
      <group targetFramework="net6.0" />
      <group targetFramework=".NETStandard2.1" />
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.StandardDateTimeFormat/bin/Release/net45/Smdn.Fundamental.StandardDateTimeFormat.dll" target="lib/net45/Smdn.Fundamental.StandardDateTimeFormat.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.StandardDateTimeFormat/bin/Release/net6.0/Smdn.Fundamental.StandardDateTimeFormat.dll" target="lib/net6.0/Smdn.Fundamental.StandardDateTimeFormat.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.StandardDateTimeFormat/bin/Release/netstandard1.0/Smdn.Fundamental.StandardDateTimeFormat.dll" target="lib/netstandard1.0/Smdn.Fundamental.StandardDateTimeFormat.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.StandardDateTimeFormat/bin/Release/netstandard1.1/Smdn.Fundamental.StandardDateTimeFormat.dll" target="lib/netstandard1.1/Smdn.Fundamental.StandardDateTimeFormat.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.StandardDateTimeFormat/bin/Release/netstandard1.3/Smdn.Fundamental.StandardDateTimeFormat.dll" target="lib/netstandard1.3/Smdn.Fundamental.StandardDateTimeFormat.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.StandardDateTimeFormat/bin/Release/netstandard1.6/Smdn.Fundamental.StandardDateTimeFormat.dll" target="lib/netstandard1.6/Smdn.Fundamental.StandardDateTimeFormat.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.StandardDateTimeFormat/bin/Release/netstandard2.1/Smdn.Fundamental.StandardDateTimeFormat.dll" target="lib/netstandard2.1/Smdn.Fundamental.StandardDateTimeFormat.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.1.1/project/images/package-icon.png" target="Smdn.Fundamental.StandardDateTimeFormat.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.StandardDateTimeFormat/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

