### PR TITLE
Release main/Smdn.Fundamental.Stream.Caching-3.0.1

### DIFF
--- a/doc/api-list/Smdn.Fundamental.Stream.Caching/Smdn.Fundamental.Stream.Caching-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Caching/Smdn.Fundamental.Stream.Caching-net45.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Stream.Caching.dll (Smdn.Fundamental.Stream.Caching-3.0.0 (net45))
+// Smdn.Fundamental.Stream.Caching.dll (Smdn.Fundamental.Stream.Caching-3.0.1)
 //   Name: Smdn.Fundamental.Stream.Caching
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (net45)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+5d6c4605b04017bfcf25bb41821556a4a8af61d6
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 

--- a/doc/api-list/Smdn.Fundamental.Stream.Caching/Smdn.Fundamental.Stream.Caching-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Caching/Smdn.Fundamental.Stream.Caching-net6.0.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.Stream.Caching
 //   AssemblyVersion: 3.0.1.0
 //   InformationalVersion: 3.0.1+5d6c4605b04017bfcf25bb41821556a4a8af61d6
-//   TargetFramework: .NETStandard,Version=v1.6
+//   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 
 using System.IO;
@@ -23,7 +23,7 @@ namespace Smdn.IO.Streams.Caching {
     public override long Length { get; }
     public override long Position { get; set; }
 
-    protected override void Dispose(bool disposing) {}
+    public override void Close() {}
     public override void Flush() {}
     protected abstract byte[] GetBlock(long blockIndex);
     public override int Read(byte[] buffer, int offset, int count) {}
@@ -42,7 +42,7 @@ namespace Smdn.IO.Streams.Caching {
     public NonPersistentCachedStream(Stream innerStream, int blockSize) {}
     public NonPersistentCachedStream(Stream innerStream, int blockSize, bool leaveInnerStreamOpen) {}
 
-    protected override void Dispose(bool disposing) {}
+    public override void Close() {}
     protected override byte[] GetBlock(long blockIndex) {}
   }
 
@@ -53,7 +53,7 @@ namespace Smdn.IO.Streams.Caching {
     public PersistentCachedStream(Stream innerStream, int blockSize) {}
     public PersistentCachedStream(Stream innerStream, int blockSize, bool leaveInnerStreamOpen) {}
 
-    protected override void Dispose(bool disposing) {}
+    public override void Close() {}
     protected override byte[] GetBlock(long blockIndex) {}
   }
 }

--- a/doc/api-list/Smdn.Fundamental.Stream.Caching/Smdn.Fundamental.Stream.Caching-netstandard1.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Caching/Smdn.Fundamental.Stream.Caching-netstandard1.1.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.Stream.Caching
 //   AssemblyVersion: 3.0.1.0
 //   InformationalVersion: 3.0.1+5d6c4605b04017bfcf25bb41821556a4a8af61d6
-//   TargetFramework: .NETStandard,Version=v1.6
+//   TargetFramework: .NETStandard,Version=v1.1
 //   Configuration: Release
 
 using System.IO;

--- a/doc/api-list/Smdn.Fundamental.Stream.Caching/Smdn.Fundamental.Stream.Caching-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Caching/Smdn.Fundamental.Stream.Caching-netstandard2.0.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.Stream.Caching
 //   AssemblyVersion: 3.0.1.0
 //   InformationalVersion: 3.0.1+5d6c4605b04017bfcf25bb41821556a4a8af61d6
-//   TargetFramework: .NETStandard,Version=v1.6
+//   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 
 using System.IO;
@@ -23,7 +23,7 @@ namespace Smdn.IO.Streams.Caching {
     public override long Length { get; }
     public override long Position { get; set; }
 
-    protected override void Dispose(bool disposing) {}
+    public override void Close() {}
     public override void Flush() {}
     protected abstract byte[] GetBlock(long blockIndex);
     public override int Read(byte[] buffer, int offset, int count) {}
@@ -42,7 +42,7 @@ namespace Smdn.IO.Streams.Caching {
     public NonPersistentCachedStream(Stream innerStream, int blockSize) {}
     public NonPersistentCachedStream(Stream innerStream, int blockSize, bool leaveInnerStreamOpen) {}
 
-    protected override void Dispose(bool disposing) {}
+    public override void Close() {}
     protected override byte[] GetBlock(long blockIndex) {}
   }
 
@@ -53,7 +53,7 @@ namespace Smdn.IO.Streams.Caching {
     public PersistentCachedStream(Stream innerStream, int blockSize) {}
     public PersistentCachedStream(Stream innerStream, int blockSize, bool leaveInnerStreamOpen) {}
 
-    protected override void Dispose(bool disposing) {}
+    public override void Close() {}
     protected override byte[] GetBlock(long blockIndex) {}
   }
 }

--- a/doc/api-list/Smdn.Fundamental.Stream.Caching/Smdn.Fundamental.Stream.Caching-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Caching/Smdn.Fundamental.Stream.Caching-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Stream.Caching.dll (Smdn.Fundamental.Stream.Caching-3.0.0 (netstandard2.1))
+// Smdn.Fundamental.Stream.Caching.dll (Smdn.Fundamental.Stream.Caching-3.0.1)
 //   Name: Smdn.Fundamental.Stream.Caching
-//   AssemblyVersion: 3.0.0.0
-//   InformationalVersion: 3.0.0 (netstandard2.1)
+//   AssemblyVersion: 3.0.1.0
+//   InformationalVersion: 3.0.1+5d6c4605b04017bfcf25bb41821556a4a8af61d6
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #100](https://github.com/smdn/Smdn.Fundamentals/actions/runs/2320337862).

# Release target
- package_target_tag: `new-release/main/Smdn.Fundamental.Stream.Caching-3.0.1`
- package_id: `Smdn.Fundamental.Stream.Caching`
- package_id_with_version: `Smdn.Fundamental.Stream.Caching-3.0.1`
- package_version: `3.0.1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.Stream.Caching-3.0.1-1652455354`
- release_tag: `releases/Smdn.Fundamental.Stream.Caching-3.0.1`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- release_note_url: [`https://gist.github.com/11f5dd1bc031f55749e855dcb604a5d5`](https://gist.github.com/11f5dd1bc031f55749e855dcb604a5d5)
- artifact_name_nupkg: `Smdn.Fundamental.Stream.Caching.3.0.1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec
```nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.Stream.Caching</id>
    <version>3.0.1</version>
    <title>Smdn.Fundamental.Stream.Caching</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.Stream.Caching.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.Stream.Caching.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp stream cache</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="5d6c4605b04017bfcf25bb41821556a4a8af61d6" />
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.1">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Shim" version="3.1.3" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Shim" version="3.1.3" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
      <group targetFramework="net6.0">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.0">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.1">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Caching/bin/Release/net45/Smdn.Fundamental.Stream.Caching.dll" target="lib/net45/Smdn.Fundamental.Stream.Caching.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Caching/bin/Release/net6.0/Smdn.Fundamental.Stream.Caching.dll" target="lib/net6.0/Smdn.Fundamental.Stream.Caching.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Caching/bin/Release/netstandard1.1/Smdn.Fundamental.Stream.Caching.dll" target="lib/netstandard1.1/Smdn.Fundamental.Stream.Caching.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Caching/bin/Release/netstandard1.6/Smdn.Fundamental.Stream.Caching.dll" target="lib/netstandard1.6/Smdn.Fundamental.Stream.Caching.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Caching/bin/Release/netstandard2.0/Smdn.Fundamental.Stream.Caching.dll" target="lib/netstandard2.0/Smdn.Fundamental.Stream.Caching.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Caching/bin/Release/netstandard2.1/Smdn.Fundamental.Stream.Caching.dll" target="lib/netstandard2.1/Smdn.Fundamental.Stream.Caching.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.1.1/project/images/package-icon.png" target="Smdn.Fundamental.Stream.Caching.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Caching/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

