### PR TITLE
Release main/Smdn.Fundamental.PrintableEncoding.Base64-3.0.2

### DIFF
--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-net472.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-net472.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.PrintableEncoding.Base64.dll (Smdn.Fundamental.PrintableEncoding.Base64-3.0.1)
+// Smdn.Fundamental.PrintableEncoding.Base64.dll (Smdn.Fundamental.PrintableEncoding.Base64-3.0.2)
 //   Name: Smdn.Fundamental.PrintableEncoding.Base64
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1+c9ae68d71ad7d729c814c50b0ec0464d38c45c66
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+d177dfeb0b6cea960613cd36dfa705263690a4a7
 //   TargetFramework: .NETFramework,Version=v4.7.2
 //   Configuration: Release
 
@@ -10,6 +10,8 @@ using System.Security.Cryptography;
 using System.Text;
 
 namespace Smdn.Formats {
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class Base64 {
     public static Stream CreateDecodingStream(Stream stream, bool leaveStreamOpen = false) {}

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-net5.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-net5.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.PrintableEncoding.Base64.dll (Smdn.Fundamental.PrintableEncoding.Base64-3.0.1)
+// Smdn.Fundamental.PrintableEncoding.Base64.dll (Smdn.Fundamental.PrintableEncoding.Base64-3.0.2)
 //   Name: Smdn.Fundamental.PrintableEncoding.Base64
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1+c9ae68d71ad7d729c814c50b0ec0464d38c45c66
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+d177dfeb0b6cea960613cd36dfa705263690a4a7
 //   TargetFramework: .NETCoreApp,Version=v5.0
 //   Configuration: Release
 
@@ -10,6 +10,8 @@ using System.Security.Cryptography;
 using System.Text;
 
 namespace Smdn.Formats {
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class Base64 {
     public static Stream CreateDecodingStream(Stream stream, bool leaveStreamOpen = false) {}

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-net6.0.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.PrintableEncoding.Base64
 //   AssemblyVersion: 3.0.2.0
 //   InformationalVersion: 3.0.2+d177dfeb0b6cea960613cd36dfa705263690a4a7
-//   TargetFramework: .NETFramework,Version=v4.5
+//   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 
 using System.IO;

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-netstandard1.3.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-netstandard1.3.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.PrintableEncoding.Base64
 //   AssemblyVersion: 3.0.2.0
 //   InformationalVersion: 3.0.2+d177dfeb0b6cea960613cd36dfa705263690a4a7
-//   TargetFramework: .NETFramework,Version=v4.5
+//   TargetFramework: .NETStandard,Version=v1.3
 //   Configuration: Release
 
 using System.IO;

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-netstandard1.6.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.PrintableEncoding.Base64.dll (Smdn.Fundamental.PrintableEncoding.Base64-3.0.1)
+// Smdn.Fundamental.PrintableEncoding.Base64.dll (Smdn.Fundamental.PrintableEncoding.Base64-3.0.2)
 //   Name: Smdn.Fundamental.PrintableEncoding.Base64
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1+c9ae68d71ad7d729c814c50b0ec0464d38c45c66
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+d177dfeb0b6cea960613cd36dfa705263690a4a7
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 
@@ -10,6 +10,8 @@ using System.Security.Cryptography;
 using System.Text;
 
 namespace Smdn.Formats {
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class Base64 {
     public static Stream CreateDecodingStream(Stream stream, bool leaveStreamOpen = false) {}

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-netstandard2.0.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.PrintableEncoding.Base64
 //   AssemblyVersion: 3.0.2.0
 //   InformationalVersion: 3.0.2+d177dfeb0b6cea960613cd36dfa705263690a4a7
-//   TargetFramework: .NETFramework,Version=v4.5
+//   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 
 using System.IO;

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.Base64/Smdn.Fundamental.PrintableEncoding.Base64-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.PrintableEncoding.Base64.dll (Smdn.Fundamental.PrintableEncoding.Base64-3.0.1)
+// Smdn.Fundamental.PrintableEncoding.Base64.dll (Smdn.Fundamental.PrintableEncoding.Base64-3.0.2)
 //   Name: Smdn.Fundamental.PrintableEncoding.Base64
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1+c9ae68d71ad7d729c814c50b0ec0464d38c45c66
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+d177dfeb0b6cea960613cd36dfa705263690a4a7
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
@@ -10,6 +10,8 @@ using System.Security.Cryptography;
 using System.Text;
 
 namespace Smdn.Formats {
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class Base64 {
     public static Stream CreateDecodingStream(Stream stream, bool leaveStreamOpen = false) {}


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #111](https://github.com/smdn/Smdn.Fundamentals/actions/runs/2372376008).

# Release target
- package_target_tag: `new-release/main/Smdn.Fundamental.PrintableEncoding.Base64-3.0.2`
- package_id: `Smdn.Fundamental.PrintableEncoding.Base64`
- package_id_with_version: `Smdn.Fundamental.PrintableEncoding.Base64-3.0.2`
- package_version: `3.0.2`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.PrintableEncoding.Base64-3.0.2-1653320434`
- release_tag: `releases/Smdn.Fundamental.PrintableEncoding.Base64-3.0.2`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- release_note_url: [`https://gist.github.com/ee93fcbf11624daa88f39b97050a0cb2`](https://gist.github.com/ee93fcbf11624daa88f39b97050a0cb2)
- artifact_name_nupkg: `Smdn.Fundamental.PrintableEncoding.Base64.3.0.2.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec
```nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.PrintableEncoding.Base64</id>
    <version>3.0.2</version>
    <title>Smdn.Fundamental.PrintableEncoding.Base64</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.PrintableEncoding.Base64.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.PrintableEncoding.Base64.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp printable-encoding base64 ICryptoTransform</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="d177dfeb0b6cea960613cd36dfa705263690a4a7" />
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Stream" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETFramework4.7.2">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Stream" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.3">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Stream" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Stream" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework="net5.0">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Stream" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework="net6.0">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Stream" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.0">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Stream" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.1">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Stream" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.Base64/bin/Release/net45/Smdn.Fundamental.PrintableEncoding.Base64.dll" target="lib/net45/Smdn.Fundamental.PrintableEncoding.Base64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.Base64/bin/Release/net472/Smdn.Fundamental.PrintableEncoding.Base64.dll" target="lib/net472/Smdn.Fundamental.PrintableEncoding.Base64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.Base64/bin/Release/net5.0/Smdn.Fundamental.PrintableEncoding.Base64.dll" target="lib/net5.0/Smdn.Fundamental.PrintableEncoding.Base64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.Base64/bin/Release/net6.0/Smdn.Fundamental.PrintableEncoding.Base64.dll" target="lib/net6.0/Smdn.Fundamental.PrintableEncoding.Base64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.Base64/bin/Release/netstandard1.3/Smdn.Fundamental.PrintableEncoding.Base64.dll" target="lib/netstandard1.3/Smdn.Fundamental.PrintableEncoding.Base64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.Base64/bin/Release/netstandard1.6/Smdn.Fundamental.PrintableEncoding.Base64.dll" target="lib/netstandard1.6/Smdn.Fundamental.PrintableEncoding.Base64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.Base64/bin/Release/netstandard2.0/Smdn.Fundamental.PrintableEncoding.Base64.dll" target="lib/netstandard2.0/Smdn.Fundamental.PrintableEncoding.Base64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.Base64/bin/Release/netstandard2.1/Smdn.Fundamental.PrintableEncoding.Base64.dll" target="lib/netstandard2.1/Smdn.Fundamental.PrintableEncoding.Base64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.1.1/project/images/package-icon.png" target="Smdn.Fundamental.PrintableEncoding.Base64.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.Base64/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

