### PR TITLE
Release main/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-3.0.2

### DIFF
--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-net45.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll (Smdn.Fundamental.PrintableEncoding.ModifiedBase64-3.0.1 (net45))
+// Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll (Smdn.Fundamental.PrintableEncoding.ModifiedBase64-3.0.2)
 //   Name: Smdn.Fundamental.PrintableEncoding.ModifiedBase64
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (net45)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+0e9f0b7daefd807b9370c2f7a3a4bf5b9cb9194a
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 
@@ -9,6 +9,8 @@ using System.Security.Cryptography;
 using Smdn.Formats.ModifiedBase64;
 
 namespace Smdn.Formats.ModifiedBase64 {
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class FromRFC2152ModifiedBase64Transform : ICryptoTransform {
     public FromRFC2152ModifiedBase64Transform() {}
@@ -26,6 +28,8 @@ namespace Smdn.Formats.ModifiedBase64 {
     public virtual byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public sealed class FromRFC3501ModifiedBase64Transform : FromRFC2152ModifiedBase64Transform {
     public FromRFC3501ModifiedBase64Transform() {}
@@ -36,6 +40,8 @@ namespace Smdn.Formats.ModifiedBase64 {
     public override byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class ModifiedUTF7 {
     public static string Decode(string str) {}
@@ -53,7 +59,9 @@ namespace Smdn.Formats.ModifiedBase64 {
 
     protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
+    [NullableContext(1)]
     public virtual int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) {}
+    [NullableContext(1)]
     public virtual byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {}
   }
 
@@ -61,7 +69,9 @@ namespace Smdn.Formats.ModifiedBase64 {
   public sealed class ToRFC3501ModifiedBase64Transform : ToRFC2152ModifiedBase64Transform {
     public ToRFC3501ModifiedBase64Transform() {}
 
+    [NullableContext(1)]
     public override int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) {}
+    [NullableContext(1)]
     public override byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {}
   }
 }

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-net5.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-net5.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll (Smdn.Fundamental.PrintableEncoding.ModifiedBase64-3.0.1 (net5.0))
+// Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll (Smdn.Fundamental.PrintableEncoding.ModifiedBase64-3.0.2)
 //   Name: Smdn.Fundamental.PrintableEncoding.ModifiedBase64
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (net5.0)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+0e9f0b7daefd807b9370c2f7a3a4bf5b9cb9194a
 //   TargetFramework: .NETCoreApp,Version=v5.0
 //   Configuration: Release
 
@@ -22,10 +22,14 @@ namespace Smdn.Formats.ModifiedBase64 {
 
     protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
+    [NullableContext(1)]
     public virtual int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) {}
+    [NullableContext(1)]
     public virtual byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public sealed class FromRFC3501ModifiedBase64Transform : FromRFC2152ModifiedBase64Transform {
     public FromRFC3501ModifiedBase64Transform() {}
@@ -36,6 +40,8 @@ namespace Smdn.Formats.ModifiedBase64 {
     public override byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class ModifiedUTF7 {
     public static string Decode(string str) {}
@@ -53,7 +59,9 @@ namespace Smdn.Formats.ModifiedBase64 {
 
     protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
+    [NullableContext(1)]
     public virtual int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) {}
+    [NullableContext(1)]
     public virtual byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {}
   }
 
@@ -61,7 +69,9 @@ namespace Smdn.Formats.ModifiedBase64 {
   public sealed class ToRFC3501ModifiedBase64Transform : ToRFC2152ModifiedBase64Transform {
     public ToRFC3501ModifiedBase64Transform() {}
 
+    [NullableContext(1)]
     public override int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) {}
+    [NullableContext(1)]
     public override byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {}
   }
 }

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-net6.0.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.PrintableEncoding.ModifiedBase64
 //   AssemblyVersion: 3.0.2.0
 //   InformationalVersion: 3.0.2+0e9f0b7daefd807b9370c2f7a3a4bf5b9cb9194a
-//   TargetFramework: .NETStandard,Version=v1.6
+//   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 
 using System.Security.Cryptography;
@@ -12,6 +12,7 @@ namespace Smdn.Formats.ModifiedBase64 {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class FromRFC2152ModifiedBase64Transform : ICryptoTransform {
     public FromRFC2152ModifiedBase64Transform() {}
+    public FromRFC2152ModifiedBase64Transform(FromBase64TransformMode mode) {}
     public FromRFC2152ModifiedBase64Transform(bool ignoreWhiteSpaces) {}
 
     public bool CanReuseTransform { get; }
@@ -32,6 +33,7 @@ namespace Smdn.Formats.ModifiedBase64 {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public sealed class FromRFC3501ModifiedBase64Transform : FromRFC2152ModifiedBase64Transform {
     public FromRFC3501ModifiedBase64Transform() {}
+    public FromRFC3501ModifiedBase64Transform(FromBase64TransformMode mode) {}
     public FromRFC3501ModifiedBase64Transform(bool ignoreWhiteSpaces) {}
 
     public override int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) {}

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-netstandard1.3.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-netstandard1.3.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.PrintableEncoding.ModifiedBase64
 //   AssemblyVersion: 3.0.2.0
 //   InformationalVersion: 3.0.2+0e9f0b7daefd807b9370c2f7a3a4bf5b9cb9194a
-//   TargetFramework: .NETStandard,Version=v1.6
+//   TargetFramework: .NETStandard,Version=v1.3
 //   Configuration: Release
 
 using System.Security.Cryptography;

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll (Smdn.Fundamental.PrintableEncoding.ModifiedBase64-3.0.1 (netstandard2.1))
+// Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll (Smdn.Fundamental.PrintableEncoding.ModifiedBase64-3.0.2)
 //   Name: Smdn.Fundamental.PrintableEncoding.ModifiedBase64
-//   AssemblyVersion: 3.0.1.0
-//   InformationalVersion: 3.0.1 (netstandard2.1)
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+0e9f0b7daefd807b9370c2f7a3a4bf5b9cb9194a
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
@@ -22,10 +22,14 @@ namespace Smdn.Formats.ModifiedBase64 {
 
     protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
+    [NullableContext(1)]
     public virtual int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) {}
+    [NullableContext(1)]
     public virtual byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public sealed class FromRFC3501ModifiedBase64Transform : FromRFC2152ModifiedBase64Transform {
     public FromRFC3501ModifiedBase64Transform() {}
@@ -36,6 +40,8 @@ namespace Smdn.Formats.ModifiedBase64 {
     public override byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class ModifiedUTF7 {
     public static string Decode(string str) {}
@@ -53,7 +59,9 @@ namespace Smdn.Formats.ModifiedBase64 {
 
     protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
+    [NullableContext(1)]
     public virtual int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) {}
+    [NullableContext(1)]
     public virtual byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {}
   }
 
@@ -61,7 +69,9 @@ namespace Smdn.Formats.ModifiedBase64 {
   public sealed class ToRFC3501ModifiedBase64Transform : ToRFC2152ModifiedBase64Transform {
     public ToRFC3501ModifiedBase64Transform() {}
 
+    [NullableContext(1)]
     public override int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) {}
+    [NullableContext(1)]
     public override byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {}
   }
 }


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #116](https://github.com/smdn/Smdn.Fundamentals/actions/runs/2379042142).

# Release target
- package_target_tag: `new-release/main/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-3.0.2`
- package_id: `Smdn.Fundamental.PrintableEncoding.ModifiedBase64`
- package_id_with_version: `Smdn.Fundamental.PrintableEncoding.ModifiedBase64-3.0.2`
- package_version: `3.0.2`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-3.0.2-1653407776`
- release_tag: `releases/Smdn.Fundamental.PrintableEncoding.ModifiedBase64-3.0.2`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- release_note_url: [`https://gist.github.com/788d7ecd86fd1a3307ba3403ef29cf83`](https://gist.github.com/788d7ecd86fd1a3307ba3403ef29cf83)
- artifact_name_nupkg: `Smdn.Fundamental.PrintableEncoding.ModifiedBase64.3.0.2.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec
```nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.PrintableEncoding.ModifiedBase64</id>
    <version>3.0.2</version>
    <title>Smdn.Fundamental.PrintableEncoding.ModifiedBase64</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.PrintableEncoding.ModifiedBase64.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp printable-encoding modified-base64 modified-utf7 RFC2152 RFC3501 ICryptoTransform</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="0e9f0b7daefd807b9370c2f7a3a4bf5b9cb9194a" />
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.Base64" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.3">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.Base64" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.Base64" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework="net5.0">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.Base64" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework="net6.0">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.Base64" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.1">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.Base64" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/bin/Release/net45/Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll" target="lib/net45/Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/bin/Release/net5.0/Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll" target="lib/net5.0/Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/bin/Release/net6.0/Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll" target="lib/net6.0/Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/bin/Release/netstandard1.3/Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll" target="lib/netstandard1.3/Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/bin/Release/netstandard1.6/Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll" target="lib/netstandard1.6/Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/bin/Release/netstandard2.1/Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll" target="lib/netstandard2.1/Smdn.Fundamental.PrintableEncoding.ModifiedBase64.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.1.1/project/images/package-icon.png" target="Smdn.Fundamental.PrintableEncoding.ModifiedBase64.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.ModifiedBase64/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

