### PR TITLE
Release main/Smdn.Fundamental.Encoding-3.0.2

### DIFF
--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-net6.0.apilist.cs
@@ -2,11 +2,12 @@
 //   Name: Smdn.Fundamental.Encoding
 //   AssemblyVersion: 3.0.2.0
 //   InformationalVersion: 3.0.2+aa0e4ec96fdd36708d229778a1b0fd543f49b04d
-//   TargetFramework: .NETFramework,Version=v4.5
+//   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
@@ -44,7 +45,7 @@ namespace Smdn.Text.Encodings {
     public static Encoding GetEncodingThrowException(string name) {}
     public static Encoding GetEncodingThrowException(string name, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding) {}
     [NullableContext(2)]
-    public static bool TryGetEncoding(string name, [Nullable] IReadOnlyDictionary<string, int> codePageCollationTable, EncodingSelectionCallback selectFallbackEncoding, [Nullable(1)] out Encoding encoding) {}
+    public static bool TryGetEncoding(string name, [Nullable] IReadOnlyDictionary<string, int> codePageCollationTable, EncodingSelectionCallback selectFallbackEncoding, [NotNullWhen(true)] [Nullable(1)] out Encoding encoding) {}
   }
 }
 

--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard1.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard1.0.apilist.cs
@@ -2,13 +2,11 @@
 //   Name: Smdn.Fundamental.Encoding
 //   AssemblyVersion: 3.0.2.0
 //   InformationalVersion: 3.0.2+aa0e4ec96fdd36708d229778a1b0fd543f49b04d
-//   TargetFramework: .NETFramework,Version=v4.5
+//   TargetFramework: .NETStandard,Version=v1.0
 //   Configuration: Release
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 using System.Text;
 using Smdn.Text.Encodings;
 
@@ -19,9 +17,7 @@ namespace Smdn.Text.Encodings {
   [Nullable(byte.MinValue)]
   [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
-  [Serializable]
   public class EncodingNotSupportedException : NotSupportedException {
-    protected EncodingNotSupportedException(SerializationInfo info, StreamingContext context) {}
     public EncodingNotSupportedException() {}
     public EncodingNotSupportedException(string encodingName) {}
     public EncodingNotSupportedException(string encodingName, Exception innerException) {}
@@ -29,8 +25,6 @@ namespace Smdn.Text.Encodings {
     public EncodingNotSupportedException(string encodingName, string message, Exception innerException) {}
 
     public string EncodingName { get; }
-
-    public override void GetObjectData(SerializationInfo info, StreamingContext context) {}
   }
 
   [Nullable(byte.MinValue)]
@@ -40,11 +34,8 @@ namespace Smdn.Text.Encodings {
     [return: Nullable(2)] public static Encoding GetEncoding(string name) {}
     [NullableContext(2)]
     public static Encoding GetEncoding([Nullable(1)] string name, EncodingSelectionCallback selectFallbackEncoding) {}
-    public static Encoding GetEncoding(string name, [Nullable] IReadOnlyDictionary<string, int> codePageCollationTable, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding) {}
     public static Encoding GetEncodingThrowException(string name) {}
     public static Encoding GetEncodingThrowException(string name, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding) {}
-    [NullableContext(2)]
-    public static bool TryGetEncoding(string name, [Nullable] IReadOnlyDictionary<string, int> codePageCollationTable, EncodingSelectionCallback selectFallbackEncoding, [Nullable(1)] out Encoding encoding) {}
   }
 }
 

--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard1.3.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard1.3.apilist.cs
@@ -2,13 +2,12 @@
 //   Name: Smdn.Fundamental.Encoding
 //   AssemblyVersion: 3.0.2.0
 //   InformationalVersion: 3.0.2+aa0e4ec96fdd36708d229778a1b0fd543f49b04d
-//   TargetFramework: .NETFramework,Version=v4.5
+//   TargetFramework: .NETStandard,Version=v1.3
 //   Configuration: Release
 
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 using System.Text;
 using Smdn.Text.Encodings;
 
@@ -21,7 +20,6 @@ namespace Smdn.Text.Encodings {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [Serializable]
   public class EncodingNotSupportedException : NotSupportedException {
-    protected EncodingNotSupportedException(SerializationInfo info, StreamingContext context) {}
     public EncodingNotSupportedException() {}
     public EncodingNotSupportedException(string encodingName) {}
     public EncodingNotSupportedException(string encodingName, Exception innerException) {}
@@ -29,8 +27,6 @@ namespace Smdn.Text.Encodings {
     public EncodingNotSupportedException(string encodingName, string message, Exception innerException) {}
 
     public string EncodingName { get; }
-
-    public override void GetObjectData(SerializationInfo info, StreamingContext context) {}
   }
 
   [Nullable(byte.MinValue)]

--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard1.6.apilist.cs
@@ -1,11 +1,13 @@
-// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.1.1)
+// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.2)
 //   Name: Smdn.Fundamental.Encoding
-//   AssemblyVersion: 3.0.1.1
-//   InformationalVersion: 3.0.1.1+a0f6e52cd3b31755404137f392bf6c953a4d28db
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+aa0e4ec96fdd36708d229778a1b0fd543f49b04d
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 
 using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Smdn.Text.Encodings;
 
@@ -13,6 +15,8 @@ namespace Smdn.Text.Encodings {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public delegate Encoding EncodingSelectionCallback(string name);
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [Serializable]
   public class EncodingNotSupportedException : NotSupportedException {
@@ -25,12 +29,18 @@ namespace Smdn.Text.Encodings {
     public string EncodingName { get; }
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class EncodingUtils {
-    public static Encoding GetEncoding(string name) {}
-    public static Encoding GetEncoding(string name, EncodingSelectionCallback selectFallbackEncoding) {}
+    [return: Nullable(2)] public static Encoding GetEncoding(string name) {}
+    [NullableContext(2)]
+    public static Encoding GetEncoding([Nullable(1)] string name, EncodingSelectionCallback selectFallbackEncoding) {}
+    public static Encoding GetEncoding(string name, [Nullable] IReadOnlyDictionary<string, int> codePageCollationTable, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding) {}
     public static Encoding GetEncodingThrowException(string name) {}
-    public static Encoding GetEncodingThrowException(string name, EncodingSelectionCallback selectFallbackEncoding) {}
+    public static Encoding GetEncodingThrowException(string name, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding) {}
+    [NullableContext(2)]
+    public static bool TryGetEncoding(string name, [Nullable] IReadOnlyDictionary<string, int> codePageCollationTable, EncodingSelectionCallback selectFallbackEncoding, [Nullable(1)] out Encoding encoding) {}
   }
 }
 

--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.0.apilist.cs
@@ -1,11 +1,13 @@
-// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.1.1)
+// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.2)
 //   Name: Smdn.Fundamental.Encoding
-//   AssemblyVersion: 3.0.1.1
-//   InformationalVersion: 3.0.1.1+a0f6e52cd3b31755404137f392bf6c953a4d28db
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+aa0e4ec96fdd36708d229778a1b0fd543f49b04d
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 
 using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
 using Smdn.Text.Encodings;
@@ -14,6 +16,8 @@ namespace Smdn.Text.Encodings {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public delegate Encoding EncodingSelectionCallback(string name);
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [Serializable]
   public class EncodingNotSupportedException : NotSupportedException {
@@ -29,12 +33,18 @@ namespace Smdn.Text.Encodings {
     public override void GetObjectData(SerializationInfo info, StreamingContext context) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class EncodingUtils {
-    public static Encoding GetEncoding(string name) {}
-    public static Encoding GetEncoding(string name, EncodingSelectionCallback selectFallbackEncoding) {}
+    [return: Nullable(2)] public static Encoding GetEncoding(string name) {}
+    [NullableContext(2)]
+    public static Encoding GetEncoding([Nullable(1)] string name, EncodingSelectionCallback selectFallbackEncoding) {}
+    public static Encoding GetEncoding(string name, [Nullable] IReadOnlyDictionary<string, int> codePageCollationTable, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding) {}
     public static Encoding GetEncodingThrowException(string name) {}
-    public static Encoding GetEncodingThrowException(string name, EncodingSelectionCallback selectFallbackEncoding) {}
+    public static Encoding GetEncodingThrowException(string name, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding) {}
+    [NullableContext(2)]
+    public static bool TryGetEncoding(string name, [Nullable] IReadOnlyDictionary<string, int> codePageCollationTable, EncodingSelectionCallback selectFallbackEncoding, [Nullable(1)] out Encoding encoding) {}
   }
 }
 

--- a/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Encoding/Smdn.Fundamental.Encoding-netstandard2.1.apilist.cs
@@ -1,11 +1,14 @@
-// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.1.1)
+// Smdn.Fundamental.Encoding.dll (Smdn.Fundamental.Encoding-3.0.2)
 //   Name: Smdn.Fundamental.Encoding
-//   AssemblyVersion: 3.0.1.1
-//   InformationalVersion: 3.0.1.1+a0f6e52cd3b31755404137f392bf6c953a4d28db
+//   AssemblyVersion: 3.0.2.0
+//   InformationalVersion: 3.0.2+aa0e4ec96fdd36708d229778a1b0fd543f49b04d
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
 using Smdn.Text.Encodings;
@@ -14,6 +17,8 @@ namespace Smdn.Text.Encodings {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public delegate Encoding EncodingSelectionCallback(string name);
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [Serializable]
   public class EncodingNotSupportedException : NotSupportedException {
@@ -29,12 +34,18 @@ namespace Smdn.Text.Encodings {
     public override void GetObjectData(SerializationInfo info, StreamingContext context) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class EncodingUtils {
-    public static Encoding GetEncoding(string name) {}
-    public static Encoding GetEncoding(string name, EncodingSelectionCallback selectFallbackEncoding) {}
+    [return: Nullable(2)] public static Encoding GetEncoding(string name) {}
+    [NullableContext(2)]
+    public static Encoding GetEncoding([Nullable(1)] string name, EncodingSelectionCallback selectFallbackEncoding) {}
+    public static Encoding GetEncoding(string name, [Nullable] IReadOnlyDictionary<string, int> codePageCollationTable, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding) {}
     public static Encoding GetEncodingThrowException(string name) {}
-    public static Encoding GetEncodingThrowException(string name, EncodingSelectionCallback selectFallbackEncoding) {}
+    public static Encoding GetEncodingThrowException(string name, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding) {}
+    [NullableContext(2)]
+    public static bool TryGetEncoding(string name, [Nullable] IReadOnlyDictionary<string, int> codePageCollationTable, EncodingSelectionCallback selectFallbackEncoding, [NotNullWhen(true)] [Nullable(1)] out Encoding encoding) {}
   }
 }
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #120](https://github.com/smdn/Smdn.Fundamentals/actions/runs/2409878371).

# Release target
- package_target_tag: `new-release/main/Smdn.Fundamental.Encoding-3.0.2`
- package_id: `Smdn.Fundamental.Encoding`
- package_id_with_version: `Smdn.Fundamental.Encoding-3.0.2`
- package_version: `3.0.2`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.Encoding-3.0.2-1653922910`
- release_tag: `releases/Smdn.Fundamental.Encoding-3.0.2`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- release_note_url: [`https://gist.github.com/022818a42a69c964e8131deced42ca62`](https://gist.github.com/022818a42a69c964e8131deced42ca62)
- artifact_name_nupkg: `Smdn.Fundamental.Encoding.3.0.2.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec
```nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.Encoding</id>
    <version>3.0.2</version>
    <title>Smdn.Fundamental.Encoding</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.Encoding.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.Encoding.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp encoding extensions</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="aa0e4ec96fdd36708d229778a1b0fd543f49b04d" />
    <dependencies>
      <group targetFramework=".NETFramework4.5" />
      <group targetFramework=".NETStandard1.0">
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.3">
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Runtime.Serialization.Formatters" version="4.3.0" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Runtime.Serialization.Formatters" version="4.3.0" exclude="Build,Analyzers" />
      </group>
      <group targetFramework="net6.0" />
      <group targetFramework=".NETStandard2.0" />
      <group targetFramework=".NETStandard2.1" />
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/net45/Smdn.Fundamental.Encoding.dll" target="lib/net45/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/net6.0/Smdn.Fundamental.Encoding.dll" target="lib/net6.0/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/netstandard1.0/Smdn.Fundamental.Encoding.dll" target="lib/netstandard1.0/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/netstandard1.3/Smdn.Fundamental.Encoding.dll" target="lib/netstandard1.3/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/netstandard1.6/Smdn.Fundamental.Encoding.dll" target="lib/netstandard1.6/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/netstandard2.0/Smdn.Fundamental.Encoding.dll" target="lib/netstandard2.0/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/netstandard2.1/Smdn.Fundamental.Encoding.dll" target="lib/netstandard2.1/Smdn.Fundamental.Encoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.1.1/project/images/package-icon.png" target="Smdn.Fundamental.Encoding.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Encoding/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

