### PR TITLE
Release main/Smdn.Fundamental.PrintableEncoding.MimeEncoding-3.1.0

### DIFF
--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.MimeEncoding/Smdn.Fundamental.PrintableEncoding.MimeEncoding-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.MimeEncoding/Smdn.Fundamental.PrintableEncoding.MimeEncoding-net45.apilist.cs
@@ -1,11 +1,13 @@
-// Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll (Smdn.Fundamental.PrintableEncoding.MimeEncoding-3.0.2)
+// Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll (Smdn.Fundamental.PrintableEncoding.MimeEncoding-3.1.0)
 //   Name: Smdn.Fundamental.PrintableEncoding.MimeEncoding
-//   AssemblyVersion: 3.0.2.0
-//   InformationalVersion: 3.0.2+1e8bd98413dde3a6f4250a3c8eaff318c493b38d
+//   AssemblyVersion: 3.1.0.0
+//   InformationalVersion: 3.1.0+0f59827eced400bac9539e303fb615aaa372eb7f
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 
+using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Smdn.Formats.Mime;
 using Smdn.Text.Encodings;
@@ -35,13 +37,15 @@ namespace Smdn.Formats.Mime {
     QuotedPrintable = 2,
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class ContentTransferEncoding {
     public const string HeaderName = "Content-Transfer-Encoding";
 
     public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding) {}
-    public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, Encoding charset) {}
-    public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, Encoding charset, bool leaveStreamOpen) {}
+    public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, [Nullable(2)] Encoding charset) {}
+    public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, [Nullable(2)] Encoding charset, bool leaveStreamOpen) {}
     public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, bool leaveStreamOpen) {}
     public static BinaryReader CreateBinaryReader(Stream stream, string encoding) {}
     public static BinaryReader CreateBinaryReader(Stream stream, string encoding, bool leaveStreamOpen) {}
@@ -53,24 +57,39 @@ namespace Smdn.Formats.Mime {
     public static StreamReader CreateTextReader(Stream stream, ContentTransferEncodingMethod encoding, Encoding charset, bool leaveStreamOpen) {}
     public static StreamReader CreateTextReader(Stream stream, string encoding, string charset) {}
     public static StreamReader CreateTextReader(Stream stream, string encoding, string charset, bool leaveStreamOpen) {}
+    [Obsolete("Use TryParse() instead.")]
     public static ContentTransferEncodingMethod GetEncodingMethod(string encoding) {}
+    [Obsolete("Use Parse() instead.")]
     public static ContentTransferEncodingMethod GetEncodingMethodThrowException(string encoding) {}
     public static string GetEncodingName(ContentTransferEncodingMethod method) {}
+    public static ContentTransferEncodingMethod Parse(string str) {}
+    [NullableContext(byte.MinValue)]
+    public static bool TryFormat(ContentTransferEncodingMethod encoding, Span<char> destination, out int charsWritten) {}
+    public static bool TryParse(string str, out ContentTransferEncodingMethod encoding) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class MimeEncoding {
+    [NullableContext(2)]
+    [return: Nullable(1)] public static string Decode([Nullable(1)] string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported, out MimeEncodingMethod encoding, out Encoding charset) {}
     public static string Decode(string str) {}
-    public static string Decode(string str, EncodingSelectionCallback selectFallbackEncoding) {}
-    public static string Decode(string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported) {}
-    public static string Decode(string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported, out MimeEncodingMethod encoding, out Encoding charset) {}
-    public static string Decode(string str, EncodingSelectionCallback selectFallbackEncoding, out MimeEncodingMethod encoding, out Encoding charset) {}
-    public static string Decode(string str, out MimeEncodingMethod encoding, out Encoding charset) {}
+    public static string Decode(string str, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding) {}
+    public static string Decode(string str, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding, [Nullable(2)] MimeEncodedWordConverter decodeMalformedOrUnsupported) {}
+    public static string Decode(string str, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding, out MimeEncodingMethod encoding, [Nullable(2)] out Encoding charset) {}
+    public static string Decode(string str, out MimeEncodingMethod encoding, [Nullable(2)] out Encoding charset) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, EncodingSelectionCallback selectFallbackEncoding) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported, out MimeEncodingMethod encoding, out Encoding charset) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, EncodingSelectionCallback selectFallbackEncoding, out MimeEncodingMethod encoding, out Encoding charset) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, out MimeEncodingMethod encoding, out Encoding charset) {}
     public static string Encode(string str, MimeEncodingMethod encoding) {}
     public static string Encode(string str, MimeEncodingMethod encoding, Encoding charset) {}

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.MimeEncoding/Smdn.Fundamental.PrintableEncoding.MimeEncoding-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.MimeEncoding/Smdn.Fundamental.PrintableEncoding.MimeEncoding-net6.0.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.PrintableEncoding.MimeEncoding
 //   AssemblyVersion: 3.1.0.0
 //   InformationalVersion: 3.1.0+0f59827eced400bac9539e303fb615aaa372eb7f
-//   TargetFramework: .NETStandard,Version=v1.6
+//   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 
 using System;

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.MimeEncoding/Smdn.Fundamental.PrintableEncoding.MimeEncoding-netstandard1.3.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.MimeEncoding/Smdn.Fundamental.PrintableEncoding.MimeEncoding-netstandard1.3.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.PrintableEncoding.MimeEncoding
 //   AssemblyVersion: 3.1.0.0
 //   InformationalVersion: 3.1.0+0f59827eced400bac9539e303fb615aaa372eb7f
-//   TargetFramework: .NETStandard,Version=v1.6
+//   TargetFramework: .NETStandard,Version=v1.3
 //   Configuration: Release
 
 using System;

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.MimeEncoding/Smdn.Fundamental.PrintableEncoding.MimeEncoding-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.MimeEncoding/Smdn.Fundamental.PrintableEncoding.MimeEncoding-netstandard2.0.apilist.cs
@@ -1,11 +1,13 @@
-// Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll (Smdn.Fundamental.PrintableEncoding.MimeEncoding-3.0.2)
+// Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll (Smdn.Fundamental.PrintableEncoding.MimeEncoding-3.1.0)
 //   Name: Smdn.Fundamental.PrintableEncoding.MimeEncoding
-//   AssemblyVersion: 3.0.2.0
-//   InformationalVersion: 3.0.2+1e8bd98413dde3a6f4250a3c8eaff318c493b38d
+//   AssemblyVersion: 3.1.0.0
+//   InformationalVersion: 3.1.0+0f59827eced400bac9539e303fb615aaa372eb7f
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 
+using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Smdn.Formats.Mime;
 using Smdn.Text.Encodings;
@@ -35,13 +37,15 @@ namespace Smdn.Formats.Mime {
     QuotedPrintable = 2,
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class ContentTransferEncoding {
     public const string HeaderName = "Content-Transfer-Encoding";
 
     public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding) {}
-    public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, Encoding charset) {}
-    public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, Encoding charset, bool leaveStreamOpen) {}
+    public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, [Nullable(2)] Encoding charset) {}
+    public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, [Nullable(2)] Encoding charset, bool leaveStreamOpen) {}
     public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, bool leaveStreamOpen) {}
     public static BinaryReader CreateBinaryReader(Stream stream, string encoding) {}
     public static BinaryReader CreateBinaryReader(Stream stream, string encoding, bool leaveStreamOpen) {}
@@ -53,24 +57,39 @@ namespace Smdn.Formats.Mime {
     public static StreamReader CreateTextReader(Stream stream, ContentTransferEncodingMethod encoding, Encoding charset, bool leaveStreamOpen) {}
     public static StreamReader CreateTextReader(Stream stream, string encoding, string charset) {}
     public static StreamReader CreateTextReader(Stream stream, string encoding, string charset, bool leaveStreamOpen) {}
+    [Obsolete("Use TryParse() instead.")]
     public static ContentTransferEncodingMethod GetEncodingMethod(string encoding) {}
+    [Obsolete("Use Parse() instead.")]
     public static ContentTransferEncodingMethod GetEncodingMethodThrowException(string encoding) {}
     public static string GetEncodingName(ContentTransferEncodingMethod method) {}
+    public static ContentTransferEncodingMethod Parse(string str) {}
+    [NullableContext(byte.MinValue)]
+    public static bool TryFormat(ContentTransferEncodingMethod encoding, Span<char> destination, out int charsWritten) {}
+    public static bool TryParse(string str, out ContentTransferEncodingMethod encoding) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class MimeEncoding {
+    [NullableContext(2)]
+    [return: Nullable(1)] public static string Decode([Nullable(1)] string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported, out MimeEncodingMethod encoding, out Encoding charset) {}
     public static string Decode(string str) {}
-    public static string Decode(string str, EncodingSelectionCallback selectFallbackEncoding) {}
-    public static string Decode(string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported) {}
-    public static string Decode(string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported, out MimeEncodingMethod encoding, out Encoding charset) {}
-    public static string Decode(string str, EncodingSelectionCallback selectFallbackEncoding, out MimeEncodingMethod encoding, out Encoding charset) {}
-    public static string Decode(string str, out MimeEncodingMethod encoding, out Encoding charset) {}
+    public static string Decode(string str, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding) {}
+    public static string Decode(string str, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding, [Nullable(2)] MimeEncodedWordConverter decodeMalformedOrUnsupported) {}
+    public static string Decode(string str, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding, out MimeEncodingMethod encoding, [Nullable(2)] out Encoding charset) {}
+    public static string Decode(string str, out MimeEncodingMethod encoding, [Nullable(2)] out Encoding charset) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, EncodingSelectionCallback selectFallbackEncoding) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported, out MimeEncodingMethod encoding, out Encoding charset) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, EncodingSelectionCallback selectFallbackEncoding, out MimeEncodingMethod encoding, out Encoding charset) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, out MimeEncodingMethod encoding, out Encoding charset) {}
     public static string Encode(string str, MimeEncodingMethod encoding) {}
     public static string Encode(string str, MimeEncodingMethod encoding, Encoding charset) {}

--- a/doc/api-list/Smdn.Fundamental.PrintableEncoding.MimeEncoding/Smdn.Fundamental.PrintableEncoding.MimeEncoding-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.PrintableEncoding.MimeEncoding/Smdn.Fundamental.PrintableEncoding.MimeEncoding-netstandard2.1.apilist.cs
@@ -1,11 +1,13 @@
-// Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll (Smdn.Fundamental.PrintableEncoding.MimeEncoding-3.0.2)
+// Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll (Smdn.Fundamental.PrintableEncoding.MimeEncoding-3.1.0)
 //   Name: Smdn.Fundamental.PrintableEncoding.MimeEncoding
-//   AssemblyVersion: 3.0.2.0
-//   InformationalVersion: 3.0.2+1e8bd98413dde3a6f4250a3c8eaff318c493b38d
+//   AssemblyVersion: 3.1.0.0
+//   InformationalVersion: 3.1.0+0f59827eced400bac9539e303fb615aaa372eb7f
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
+using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Smdn.Formats.Mime;
 using Smdn.Text.Encodings;
@@ -35,13 +37,15 @@ namespace Smdn.Formats.Mime {
     QuotedPrintable = 2,
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class ContentTransferEncoding {
     public const string HeaderName = "Content-Transfer-Encoding";
 
     public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding) {}
-    public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, Encoding charset) {}
-    public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, Encoding charset, bool leaveStreamOpen) {}
+    public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, [Nullable(2)] Encoding charset) {}
+    public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, [Nullable(2)] Encoding charset, bool leaveStreamOpen) {}
     public static BinaryReader CreateBinaryReader(Stream stream, ContentTransferEncodingMethod encoding, bool leaveStreamOpen) {}
     public static BinaryReader CreateBinaryReader(Stream stream, string encoding) {}
     public static BinaryReader CreateBinaryReader(Stream stream, string encoding, bool leaveStreamOpen) {}
@@ -53,24 +57,39 @@ namespace Smdn.Formats.Mime {
     public static StreamReader CreateTextReader(Stream stream, ContentTransferEncodingMethod encoding, Encoding charset, bool leaveStreamOpen) {}
     public static StreamReader CreateTextReader(Stream stream, string encoding, string charset) {}
     public static StreamReader CreateTextReader(Stream stream, string encoding, string charset, bool leaveStreamOpen) {}
+    [Obsolete("Use TryParse() instead.")]
     public static ContentTransferEncodingMethod GetEncodingMethod(string encoding) {}
+    [Obsolete("Use Parse() instead.")]
     public static ContentTransferEncodingMethod GetEncodingMethodThrowException(string encoding) {}
     public static string GetEncodingName(ContentTransferEncodingMethod method) {}
+    public static ContentTransferEncodingMethod Parse(string str) {}
+    [NullableContext(byte.MinValue)]
+    public static bool TryFormat(ContentTransferEncodingMethod encoding, Span<char> destination, out int charsWritten) {}
+    public static bool TryParse(string str, out ContentTransferEncodingMethod encoding) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public static class MimeEncoding {
+    [NullableContext(2)]
+    [return: Nullable(1)] public static string Decode([Nullable(1)] string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported, out MimeEncodingMethod encoding, out Encoding charset) {}
     public static string Decode(string str) {}
-    public static string Decode(string str, EncodingSelectionCallback selectFallbackEncoding) {}
-    public static string Decode(string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported) {}
-    public static string Decode(string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported, out MimeEncodingMethod encoding, out Encoding charset) {}
-    public static string Decode(string str, EncodingSelectionCallback selectFallbackEncoding, out MimeEncodingMethod encoding, out Encoding charset) {}
-    public static string Decode(string str, out MimeEncodingMethod encoding, out Encoding charset) {}
+    public static string Decode(string str, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding) {}
+    public static string Decode(string str, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding, [Nullable(2)] MimeEncodedWordConverter decodeMalformedOrUnsupported) {}
+    public static string Decode(string str, [Nullable(2)] EncodingSelectionCallback selectFallbackEncoding, out MimeEncodingMethod encoding, [Nullable(2)] out Encoding charset) {}
+    public static string Decode(string str, out MimeEncodingMethod encoding, [Nullable(2)] out Encoding charset) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, EncodingSelectionCallback selectFallbackEncoding) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, EncodingSelectionCallback selectFallbackEncoding, MimeEncodedWordConverter decodeMalformedOrUnsupported, out MimeEncodingMethod encoding, out Encoding charset) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, EncodingSelectionCallback selectFallbackEncoding, out MimeEncodingMethod encoding, out Encoding charset) {}
+    [NullableContext(2)]
     public static string DecodeNullable(string str, out MimeEncodingMethod encoding, out Encoding charset) {}
     public static string Encode(string str, MimeEncodingMethod encoding) {}
     public static string Encode(string str, MimeEncodingMethod encoding, Encoding charset) {}


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #123](https://github.com/smdn/Smdn.Fundamentals/actions/runs/2431342568).

# Release target
- package_target_tag: `new-release/main/Smdn.Fundamental.PrintableEncoding.MimeEncoding-3.1.0`
- package_id: `Smdn.Fundamental.PrintableEncoding.MimeEncoding`
- package_id_with_version: `Smdn.Fundamental.PrintableEncoding.MimeEncoding-3.1.0`
- package_version: `3.1.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.PrintableEncoding.MimeEncoding-3.1.0-1654211223`
- release_tag: `releases/Smdn.Fundamental.PrintableEncoding.MimeEncoding-3.1.0`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- release_note_url: [`https://gist.github.com/e8c7851ebf01751b9ba0c5548b729522`](https://gist.github.com/e8c7851ebf01751b9ba0c5548b729522)
- artifact_name_nupkg: `Smdn.Fundamental.PrintableEncoding.MimeEncoding.3.1.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec
```nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.PrintableEncoding.MimeEncoding</id>
    <version>3.1.0</version>
    <title>Smdn.Fundamental.PrintableEncoding.MimeEncoding</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.PrintableEncoding.MimeEncoding.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp printable-encoding MIME mime-encoding RFC2045 RFC2047 RFC2822 stream reader writer</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="0f59827eced400bac9539e303fb615aaa372eb7f" />
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Encoding" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.Base64" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.QuotedPrintable" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.UUEncoding" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="System.ValueTuple" version="4.5.0" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.3">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Encoding" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.Base64" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.QuotedPrintable" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.UUEncoding" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.ValueTuple" version="4.5.0" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Encoding" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.Base64" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.QuotedPrintable" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.UUEncoding" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.ValueTuple" version="4.5.0" exclude="Build,Analyzers" />
      </group>
      <group targetFramework="net6.0">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Encoding" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.Base64" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.QuotedPrintable" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.UUEncoding" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.0">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Encoding" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.Base64" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.QuotedPrintable" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.UUEncoding" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.1">
        <dependency id="Smdn.Fundamental.CryptoTransform" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Encoding" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.Base64" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.QuotedPrintable" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="Smdn.Fundamental.PrintableEncoding.UUEncoding" version="[3.0.2, 4.0.0)" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.MimeEncoding/bin/Release/net45/Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll" target="lib/net45/Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.MimeEncoding/bin/Release/net6.0/Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll" target="lib/net6.0/Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.MimeEncoding/bin/Release/netstandard1.3/Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll" target="lib/netstandard1.3/Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.MimeEncoding/bin/Release/netstandard1.6/Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll" target="lib/netstandard1.6/Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.MimeEncoding/bin/Release/netstandard2.0/Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll" target="lib/netstandard2.0/Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.MimeEncoding/bin/Release/netstandard2.1/Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll" target="lib/netstandard2.1/Smdn.Fundamental.PrintableEncoding.MimeEncoding.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.1.1/project/images/package-icon.png" target="Smdn.Fundamental.PrintableEncoding.MimeEncoding.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.PrintableEncoding.MimeEncoding/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

