### PR TITLE
Release main/Smdn.Fundamental.Stream.Extending-3.0.3

### DIFF
--- a/doc/api-list/Smdn.Fundamental.Stream.Extending/Smdn.Fundamental.Stream.Extending-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Extending/Smdn.Fundamental.Stream.Extending-net45.apilist.cs
@@ -1,20 +1,25 @@
-// Smdn.Fundamental.Stream.Extending.dll (Smdn.Fundamental.Stream.Extending-3.0.2)
+// Smdn.Fundamental.Stream.Extending.dll (Smdn.Fundamental.Stream.Extending-3.0.3)
 //   Name: Smdn.Fundamental.Stream.Extending
-//   AssemblyVersion: 3.0.2.0
-//   InformationalVersion: 3.0.2+60d5c23ca06a9ab9d31d1fafc141dedbc6b86edf
+//   AssemblyVersion: 3.0.3.0
+//   InformationalVersion: 3.0.3+62b030d52118749c63983987fb6ae99a47e81e56
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.IO.Streams.Extending;
 
 namespace Smdn.IO.Streams.Extending {
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class ExtendStream : ExtendStreamBase {
-    public ExtendStream(Stream innerStream, Stream prependStream, Stream appendStream, bool leaveInnerStreamOpen = true, bool leavePrependStreamOpen = true, bool leaveAppendStreamOpen = true) {}
-    public ExtendStream(Stream innerStream, byte[] prependData, byte[] appendData, bool leaveInnerStreamOpen = true) {}
+    [NullableContext(2)]
+    public ExtendStream([Nullable(1)] Stream innerStream, Stream prependStream, Stream appendStream, bool leaveInnerStreamOpen = true, bool leavePrependStreamOpen = true, bool leaveAppendStreamOpen = true) {}
+    [NullableContext(2)]
+    public ExtendStream([Nullable(1)] Stream innerStream, byte[] prependData, byte[] appendData, bool leaveInnerStreamOpen = true) {}
 
     protected override bool CanSeekAppendedData { get; }
     protected override bool CanSeekPrependedData { get; }
@@ -28,8 +33,11 @@ namespace Smdn.IO.Streams.Extending {
     protected override void SetPrependedDataPosition(long position) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public abstract class ExtendStreamBase : Stream {
+    [NullableContext(byte.MinValue)]
     protected enum StreamSection : int {
       Append = 2,
       EndOfStream = 3,

--- a/doc/api-list/Smdn.Fundamental.Stream.Extending/Smdn.Fundamental.Stream.Extending-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Extending/Smdn.Fundamental.Stream.Extending-net6.0.apilist.cs
@@ -1,21 +1,26 @@
-// Smdn.Fundamental.Stream.Extending.dll (Smdn.Fundamental.Stream.Extending-3.0.2)
+// Smdn.Fundamental.Stream.Extending.dll (Smdn.Fundamental.Stream.Extending-3.0.3)
 //   Name: Smdn.Fundamental.Stream.Extending
-//   AssemblyVersion: 3.0.2.0
-//   InformationalVersion: 3.0.2+60d5c23ca06a9ab9d31d1fafc141dedbc6b86edf
+//   AssemblyVersion: 3.0.3.0
+//   InformationalVersion: 3.0.3+62b030d52118749c63983987fb6ae99a47e81e56
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.IO.Streams.Extending;
 
 namespace Smdn.IO.Streams.Extending {
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class ExtendStream : ExtendStreamBase {
-    public ExtendStream(Stream innerStream, Stream prependStream, Stream appendStream, bool leaveInnerStreamOpen = true, bool leavePrependStreamOpen = true, bool leaveAppendStreamOpen = true) {}
-    public ExtendStream(Stream innerStream, byte[] prependData, byte[] appendData, bool leaveInnerStreamOpen = true) {}
+    [NullableContext(2)]
+    public ExtendStream([Nullable(1)] Stream innerStream, Stream prependStream, Stream appendStream, bool leaveInnerStreamOpen = true, bool leavePrependStreamOpen = true, bool leaveAppendStreamOpen = true) {}
+    [NullableContext(2)]
+    public ExtendStream([Nullable(1)] Stream innerStream, byte[] prependData, byte[] appendData, bool leaveInnerStreamOpen = true) {}
 
     protected override bool CanSeekAppendedData { get; }
     protected override bool CanSeekPrependedData { get; }
@@ -23,14 +28,21 @@ namespace Smdn.IO.Streams.Extending {
     public override void Close() {}
     protected override int ReadAppendedData(byte[] buffer, int offset, int count) {}
     protected override Task<int> ReadAppendedDataAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    [NullableContext(byte.MinValue)]
+    protected override ValueTask<int> ReadAppendedDataAsync(Memory<byte> buffer, CancellationToken cancellationToken) {}
     protected override int ReadPrependedData(byte[] buffer, int offset, int count) {}
     protected override Task<int> ReadPrependedDataAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    [NullableContext(byte.MinValue)]
+    protected override ValueTask<int> ReadPrependedDataAsync(Memory<byte> buffer, CancellationToken cancellationToken) {}
     protected override void SetAppendedDataPosition(long position) {}
     protected override void SetPrependedDataPosition(long position) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public abstract class ExtendStreamBase : Stream {
+    [NullableContext(byte.MinValue)]
     protected enum StreamSection : int {
       Append = 2,
       EndOfStream = 3,
@@ -58,9 +70,17 @@ namespace Smdn.IO.Streams.Extending {
     public override int Read(byte[] buffer, int offset, int count) {}
     protected abstract int ReadAppendedData(byte[] buffer, int offset, int count);
     protected abstract Task<int> ReadAppendedDataAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
+    [AsyncStateMachine]
+    [NullableContext(byte.MinValue)]
+    protected virtual ValueTask<int> ReadAppendedDataAsync(Memory<byte> buffer, CancellationToken cancellationToken) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    [NullableContext(byte.MinValue)]
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) {}
     protected abstract int ReadPrependedData(byte[] buffer, int offset, int count);
     protected abstract Task<int> ReadPrependedDataAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
+    [AsyncStateMachine]
+    [NullableContext(byte.MinValue)]
+    protected virtual ValueTask<int> ReadPrependedDataAsync(Memory<byte> buffer, CancellationToken cancellationToken) {}
     public override long Seek(long offset, SeekOrigin origin) {}
     protected abstract void SetAppendedDataPosition(long position);
     public override void SetLength(long @value) {}
@@ -68,6 +88,7 @@ namespace Smdn.IO.Streams.Extending {
     protected void ThrowIfDisposed() {}
     public override void Write(byte[] buffer, int offset, int count) {}
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    [NullableContext(byte.MinValue)]
     public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
   }
 }

--- a/doc/api-list/Smdn.Fundamental.Stream.Extending/Smdn.Fundamental.Stream.Extending-netstandard1.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Extending/Smdn.Fundamental.Stream.Extending-netstandard1.0.apilist.cs
@@ -1,20 +1,25 @@
-// Smdn.Fundamental.Stream.Extending.dll (Smdn.Fundamental.Stream.Extending-3.0.2)
+// Smdn.Fundamental.Stream.Extending.dll (Smdn.Fundamental.Stream.Extending-3.0.3)
 //   Name: Smdn.Fundamental.Stream.Extending
-//   AssemblyVersion: 3.0.2.0
-//   InformationalVersion: 3.0.2+60d5c23ca06a9ab9d31d1fafc141dedbc6b86edf
+//   AssemblyVersion: 3.0.3.0
+//   InformationalVersion: 3.0.3+62b030d52118749c63983987fb6ae99a47e81e56
 //   TargetFramework: .NETStandard,Version=v1.0
 //   Configuration: Release
 
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.IO.Streams.Extending;
 
 namespace Smdn.IO.Streams.Extending {
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class ExtendStream : ExtendStreamBase {
-    public ExtendStream(Stream innerStream, Stream prependStream, Stream appendStream, bool leaveInnerStreamOpen = true, bool leavePrependStreamOpen = true, bool leaveAppendStreamOpen = true) {}
-    public ExtendStream(Stream innerStream, byte[] prependData, byte[] appendData, bool leaveInnerStreamOpen = true) {}
+    [NullableContext(2)]
+    public ExtendStream([Nullable(1)] Stream innerStream, Stream prependStream, Stream appendStream, bool leaveInnerStreamOpen = true, bool leavePrependStreamOpen = true, bool leaveAppendStreamOpen = true) {}
+    [NullableContext(2)]
+    public ExtendStream([Nullable(1)] Stream innerStream, byte[] prependData, byte[] appendData, bool leaveInnerStreamOpen = true) {}
 
     protected override bool CanSeekAppendedData { get; }
     protected override bool CanSeekPrependedData { get; }
@@ -28,8 +33,11 @@ namespace Smdn.IO.Streams.Extending {
     protected override void SetPrependedDataPosition(long position) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public abstract class ExtendStreamBase : Stream {
+    [NullableContext(byte.MinValue)]
     protected enum StreamSection : int {
       Append = 2,
       EndOfStream = 3,

--- a/doc/api-list/Smdn.Fundamental.Stream.Extending/Smdn.Fundamental.Stream.Extending-netstandard1.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Extending/Smdn.Fundamental.Stream.Extending-netstandard1.1.apilist.cs
@@ -2,7 +2,7 @@
 //   Name: Smdn.Fundamental.Stream.Extending
 //   AssemblyVersion: 3.0.3.0
 //   InformationalVersion: 3.0.3+62b030d52118749c63983987fb6ae99a47e81e56
-//   TargetFramework: .NETStandard,Version=v1.6
+//   TargetFramework: .NETStandard,Version=v1.1
 //   Configuration: Release
 
 using System.IO;

--- a/doc/api-list/Smdn.Fundamental.Stream.Extending/Smdn.Fundamental.Stream.Extending-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Extending/Smdn.Fundamental.Stream.Extending-netstandard2.0.apilist.cs
@@ -1,20 +1,25 @@
-// Smdn.Fundamental.Stream.Extending.dll (Smdn.Fundamental.Stream.Extending-3.0.2)
+// Smdn.Fundamental.Stream.Extending.dll (Smdn.Fundamental.Stream.Extending-3.0.3)
 //   Name: Smdn.Fundamental.Stream.Extending
-//   AssemblyVersion: 3.0.2.0
-//   InformationalVersion: 3.0.2+60d5c23ca06a9ab9d31d1fafc141dedbc6b86edf
+//   AssemblyVersion: 3.0.3.0
+//   InformationalVersion: 3.0.3+62b030d52118749c63983987fb6ae99a47e81e56
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.IO.Streams.Extending;
 
 namespace Smdn.IO.Streams.Extending {
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class ExtendStream : ExtendStreamBase {
-    public ExtendStream(Stream innerStream, Stream prependStream, Stream appendStream, bool leaveInnerStreamOpen = true, bool leavePrependStreamOpen = true, bool leaveAppendStreamOpen = true) {}
-    public ExtendStream(Stream innerStream, byte[] prependData, byte[] appendData, bool leaveInnerStreamOpen = true) {}
+    [NullableContext(2)]
+    public ExtendStream([Nullable(1)] Stream innerStream, Stream prependStream, Stream appendStream, bool leaveInnerStreamOpen = true, bool leavePrependStreamOpen = true, bool leaveAppendStreamOpen = true) {}
+    [NullableContext(2)]
+    public ExtendStream([Nullable(1)] Stream innerStream, byte[] prependData, byte[] appendData, bool leaveInnerStreamOpen = true) {}
 
     protected override bool CanSeekAppendedData { get; }
     protected override bool CanSeekPrependedData { get; }
@@ -28,8 +33,11 @@ namespace Smdn.IO.Streams.Extending {
     protected override void SetPrependedDataPosition(long position) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public abstract class ExtendStreamBase : Stream {
+    [NullableContext(byte.MinValue)]
     protected enum StreamSection : int {
       Append = 2,
       EndOfStream = 3,

--- a/doc/api-list/Smdn.Fundamental.Stream.Extending/Smdn.Fundamental.Stream.Extending-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Stream.Extending/Smdn.Fundamental.Stream.Extending-netstandard2.1.apilist.cs
@@ -1,21 +1,26 @@
-// Smdn.Fundamental.Stream.Extending.dll (Smdn.Fundamental.Stream.Extending-3.0.2)
+// Smdn.Fundamental.Stream.Extending.dll (Smdn.Fundamental.Stream.Extending-3.0.3)
 //   Name: Smdn.Fundamental.Stream.Extending
-//   AssemblyVersion: 3.0.2.0
-//   InformationalVersion: 3.0.2+60d5c23ca06a9ab9d31d1fafc141dedbc6b86edf
+//   AssemblyVersion: 3.0.3.0
+//   InformationalVersion: 3.0.3+62b030d52118749c63983987fb6ae99a47e81e56
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Smdn.IO.Streams.Extending;
 
 namespace Smdn.IO.Streams.Extending {
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public class ExtendStream : ExtendStreamBase {
-    public ExtendStream(Stream innerStream, Stream prependStream, Stream appendStream, bool leaveInnerStreamOpen = true, bool leavePrependStreamOpen = true, bool leaveAppendStreamOpen = true) {}
-    public ExtendStream(Stream innerStream, byte[] prependData, byte[] appendData, bool leaveInnerStreamOpen = true) {}
+    [NullableContext(2)]
+    public ExtendStream([Nullable(1)] Stream innerStream, Stream prependStream, Stream appendStream, bool leaveInnerStreamOpen = true, bool leavePrependStreamOpen = true, bool leaveAppendStreamOpen = true) {}
+    [NullableContext(2)]
+    public ExtendStream([Nullable(1)] Stream innerStream, byte[] prependData, byte[] appendData, bool leaveInnerStreamOpen = true) {}
 
     protected override bool CanSeekAppendedData { get; }
     protected override bool CanSeekPrependedData { get; }
@@ -23,14 +28,21 @@ namespace Smdn.IO.Streams.Extending {
     public override void Close() {}
     protected override int ReadAppendedData(byte[] buffer, int offset, int count) {}
     protected override Task<int> ReadAppendedDataAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    [NullableContext(byte.MinValue)]
+    protected override ValueTask<int> ReadAppendedDataAsync(Memory<byte> buffer, CancellationToken cancellationToken) {}
     protected override int ReadPrependedData(byte[] buffer, int offset, int count) {}
     protected override Task<int> ReadPrependedDataAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    [NullableContext(byte.MinValue)]
+    protected override ValueTask<int> ReadPrependedDataAsync(Memory<byte> buffer, CancellationToken cancellationToken) {}
     protected override void SetAppendedDataPosition(long position) {}
     protected override void SetPrependedDataPosition(long position) {}
   }
 
+  [Nullable(byte.MinValue)]
+  [NullableContext(1)]
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   public abstract class ExtendStreamBase : Stream {
+    [NullableContext(byte.MinValue)]
     protected enum StreamSection : int {
       Append = 2,
       EndOfStream = 3,
@@ -58,9 +70,17 @@ namespace Smdn.IO.Streams.Extending {
     public override int Read(byte[] buffer, int offset, int count) {}
     protected abstract int ReadAppendedData(byte[] buffer, int offset, int count);
     protected abstract Task<int> ReadAppendedDataAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
+    [AsyncStateMachine]
+    [NullableContext(byte.MinValue)]
+    protected virtual ValueTask<int> ReadAppendedDataAsync(Memory<byte> buffer, CancellationToken cancellationToken) {}
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    [NullableContext(byte.MinValue)]
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) {}
     protected abstract int ReadPrependedData(byte[] buffer, int offset, int count);
     protected abstract Task<int> ReadPrependedDataAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
+    [AsyncStateMachine]
+    [NullableContext(byte.MinValue)]
+    protected virtual ValueTask<int> ReadPrependedDataAsync(Memory<byte> buffer, CancellationToken cancellationToken) {}
     public override long Seek(long offset, SeekOrigin origin) {}
     protected abstract void SetAppendedDataPosition(long position);
     public override void SetLength(long @value) {}
@@ -68,6 +88,7 @@ namespace Smdn.IO.Streams.Extending {
     protected void ThrowIfDisposed() {}
     public override void Write(byte[] buffer, int offset, int count) {}
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {}
+    [NullableContext(byte.MinValue)]
     public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {}
   }
 }


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #129](https://github.com/smdn/Smdn.Fundamentals/actions/runs/2451248877).

# Release target
- package_target_tag: `new-release/main/Smdn.Fundamental.Stream.Extending-3.0.3`
- package_id: `Smdn.Fundamental.Stream.Extending`
- package_id_with_version: `Smdn.Fundamental.Stream.Extending-3.0.3`
- package_version: `3.0.3`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.Stream.Extending-3.0.3-1654560448`
- release_tag: `releases/Smdn.Fundamental.Stream.Extending-3.0.3`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- release_note_url: [`https://gist.github.com/0175ec48437efc2133a2bab06c8d976f`](https://gist.github.com/0175ec48437efc2133a2bab06c8d976f)
- artifact_name_nupkg: `Smdn.Fundamental.Stream.Extending.3.0.3.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec
```nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Fundamental.Stream.Extending</id>
    <version>3.0.3</version>
    <title>Smdn.Fundamental.Stream.Extending</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Fundamental.Stream.Extending.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
    <description>Smdn.Fundamental.Stream.Extending.dll</description>
    <copyright>Copyright © 2021 smdn</copyright>
    <tags>smdn.jp stream extending</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="62b030d52118749c63983987fb6ae99a47e81e56" />
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.0">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.1">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework="net6.0">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.0">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.1">
        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Extending/bin/Release/net45/Smdn.Fundamental.Stream.Extending.dll" target="lib/net45/Smdn.Fundamental.Stream.Extending.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Extending/bin/Release/net6.0/Smdn.Fundamental.Stream.Extending.dll" target="lib/net6.0/Smdn.Fundamental.Stream.Extending.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Extending/bin/Release/netstandard1.0/Smdn.Fundamental.Stream.Extending.dll" target="lib/netstandard1.0/Smdn.Fundamental.Stream.Extending.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Extending/bin/Release/netstandard1.1/Smdn.Fundamental.Stream.Extending.dll" target="lib/netstandard1.1/Smdn.Fundamental.Stream.Extending.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Extending/bin/Release/netstandard1.6/Smdn.Fundamental.Stream.Extending.dll" target="lib/netstandard1.6/Smdn.Fundamental.Stream.Extending.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Extending/bin/Release/netstandard2.0/Smdn.Fundamental.Stream.Extending.dll" target="lib/netstandard2.0/Smdn.Fundamental.Stream.Extending.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Extending/bin/Release/netstandard2.1/Smdn.Fundamental.Stream.Extending.dll" target="lib/netstandard2.1/Smdn.Fundamental.Stream.Extending.dll" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.1.1/project/images/package-icon.png" target="Smdn.Fundamental.Stream.Extending.png" />
    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Stream.Extending/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

