### PR TITLE
Release main/Smdn.Fundamental.UInt24n-4.0.0

### DIFF
--- a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-net45.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.1.0)
+// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-4.0.0)
 //   Name: Smdn.Fundamental.UInt24n
-//   AssemblyVersion: 3.1.0.0
-//   InformationalVersion: 3.1.0+d0bc2ff12d7b860e40c08a17db9b68fff731fb10
+//   AssemblyVersion: 4.0.0.0
+//   InformationalVersion: 4.0.0+67b803a21469d1c9d14f260a6414b9e666a8e282
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 //   Referenced assemblies:
@@ -18,7 +18,7 @@ using Smdn;
 namespace Smdn {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
-  public struct UInt24 :
+  public readonly struct UInt24 :
     IComparable,
     IComparable<UInt24>,
     IComparable<int>,
@@ -98,13 +98,6 @@ namespace Smdn {
     public static UInt24 operator + (UInt24 @value) {}
     public static UInt24 operator >>> (UInt24 @value, int shiftAmount) {}
 
-    [FieldOffset(0)]
-    public byte Byte0;
-    [FieldOffset(1)]
-    public byte Byte1;
-    [FieldOffset(2)]
-    public byte Byte2;
-
     public UInt24(ReadOnlySpan<byte> @value, bool isBigEndian = false) {}
     public UInt24(byte[] @value, bool isBigEndian = false) {}
     public UInt24(byte[] @value, int startIndex, bool isBigEndian = false) {}
@@ -117,37 +110,37 @@ namespace Smdn {
     public bool Equals(int other) {}
     public bool Equals(uint other) {}
     public override bool Equals(object obj) {}
-    public override readonly int GetHashCode() {}
+    public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
-    readonly byte IConvertible.ToByte(IFormatProvider provider) {}
+    byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
     short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
-    readonly long IConvertible.ToInt64(IFormatProvider provider) {}
-    readonly sbyte IConvertible.ToSByte(IFormatProvider provider) {}
+    long IConvertible.ToInt64(IFormatProvider provider) {}
+    sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
     ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
-    readonly ulong IConvertible.ToUInt64(IFormatProvider provider) {}
-    public readonly int ToInt32() {}
+    ulong IConvertible.ToUInt64(IFormatProvider provider) {}
+    public int ToInt32() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
-    public readonly uint ToUInt32() {}
-    public readonly bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
-    public readonly bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
+    public uint ToUInt32() {}
+    public bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
-  public struct UInt48 :
+  public readonly struct UInt48 :
     IComparable,
     IComparable<UInt48>,
     IComparable<long>,
@@ -227,19 +220,6 @@ namespace Smdn {
     public static UInt48 operator + (UInt48 @value) {}
     public static UInt48 operator >>> (UInt48 @value, int shiftAmount) {}
 
-    [FieldOffset(0)]
-    public byte Byte0;
-    [FieldOffset(1)]
-    public byte Byte1;
-    [FieldOffset(2)]
-    public byte Byte2;
-    [FieldOffset(3)]
-    public byte Byte3;
-    [FieldOffset(4)]
-    public byte Byte4;
-    [FieldOffset(5)]
-    public byte Byte5;
-
     public UInt48(ReadOnlySpan<byte> @value, bool isBigEndian = false) {}
     public UInt48(byte[] @value, bool isBigEndian = false) {}
     public UInt48(byte[] @value, int startIndex, bool isBigEndian = false) {}
@@ -252,32 +232,32 @@ namespace Smdn {
     public bool Equals(long other) {}
     public bool Equals(ulong other) {}
     public override bool Equals(object obj) {}
-    public override readonly int GetHashCode() {}
+    public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
-    readonly byte IConvertible.ToByte(IFormatProvider provider) {}
+    byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
-    readonly short IConvertible.ToInt16(IFormatProvider provider) {}
+    short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
     long IConvertible.ToInt64(IFormatProvider provider) {}
-    readonly sbyte IConvertible.ToSByte(IFormatProvider provider) {}
+    sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
-    readonly ushort IConvertible.ToUInt16(IFormatProvider provider) {}
+    ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
     ulong IConvertible.ToUInt64(IFormatProvider provider) {}
-    public readonly long ToInt64() {}
+    public long ToInt64() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
-    public readonly ulong ToUInt64() {}
-    public readonly bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
-    public readonly bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
+    public ulong ToUInt64() {}
+    public bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.3.2.0.

--- a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.1.0)
+// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-4.0.0)
 //   Name: Smdn.Fundamental.UInt24n
-//   AssemblyVersion: 3.1.0.0
-//   InformationalVersion: 3.1.0+d0bc2ff12d7b860e40c08a17db9b68fff731fb10
+//   AssemblyVersion: 4.0.0.0
+//   InformationalVersion: 4.0.0+67b803a21469d1c9d14f260a6414b9e666a8e282
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -17,7 +17,7 @@ using Smdn;
 namespace Smdn {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
-  public struct UInt24 :
+  public readonly struct UInt24 :
     IComparable,
     IComparable<UInt24>,
     IComparable<int>,
@@ -101,13 +101,6 @@ namespace Smdn {
     public static UInt24 operator + (UInt24 @value) {}
     public static UInt24 operator >>> (UInt24 @value, int shiftAmount) {}
 
-    [FieldOffset(0)]
-    public byte Byte0;
-    [FieldOffset(1)]
-    public byte Byte1;
-    [FieldOffset(2)]
-    public byte Byte2;
-
     public UInt24(ReadOnlySpan<byte> @value, bool isBigEndian = false) {}
     public UInt24(byte[] @value, bool isBigEndian = false) {}
     public UInt24(byte[] @value, int startIndex, bool isBigEndian = false) {}
@@ -120,38 +113,38 @@ namespace Smdn {
     public bool Equals(int other) {}
     public bool Equals(uint other) {}
     public override bool Equals(object obj) {}
-    public override readonly int GetHashCode() {}
+    public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
-    readonly byte IConvertible.ToByte(IFormatProvider provider) {}
+    byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
     short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
-    readonly long IConvertible.ToInt64(IFormatProvider provider) {}
-    readonly sbyte IConvertible.ToSByte(IFormatProvider provider) {}
+    long IConvertible.ToInt64(IFormatProvider provider) {}
+    sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
     ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
-    readonly ulong IConvertible.ToUInt64(IFormatProvider provider) {}
-    public readonly int ToInt32() {}
+    ulong IConvertible.ToUInt64(IFormatProvider provider) {}
+    public int ToInt32() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
-    public readonly uint ToUInt32() {}
+    public uint ToUInt32() {}
     public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider) {}
-    public readonly bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
-    public readonly bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
-  public struct UInt48 :
+  public readonly struct UInt48 :
     IComparable,
     IComparable<UInt48>,
     IComparable<long>,
@@ -235,19 +228,6 @@ namespace Smdn {
     public static UInt48 operator + (UInt48 @value) {}
     public static UInt48 operator >>> (UInt48 @value, int shiftAmount) {}
 
-    [FieldOffset(0)]
-    public byte Byte0;
-    [FieldOffset(1)]
-    public byte Byte1;
-    [FieldOffset(2)]
-    public byte Byte2;
-    [FieldOffset(3)]
-    public byte Byte3;
-    [FieldOffset(4)]
-    public byte Byte4;
-    [FieldOffset(5)]
-    public byte Byte5;
-
     public UInt48(ReadOnlySpan<byte> @value, bool isBigEndian = false) {}
     public UInt48(byte[] @value, bool isBigEndian = false) {}
     public UInt48(byte[] @value, int startIndex, bool isBigEndian = false) {}
@@ -260,33 +240,33 @@ namespace Smdn {
     public bool Equals(long other) {}
     public bool Equals(ulong other) {}
     public override bool Equals(object obj) {}
-    public override readonly int GetHashCode() {}
+    public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
-    readonly byte IConvertible.ToByte(IFormatProvider provider) {}
+    byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
-    readonly short IConvertible.ToInt16(IFormatProvider provider) {}
+    short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
     long IConvertible.ToInt64(IFormatProvider provider) {}
-    readonly sbyte IConvertible.ToSByte(IFormatProvider provider) {}
+    sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
-    readonly ushort IConvertible.ToUInt16(IFormatProvider provider) {}
+    ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
     ulong IConvertible.ToUInt64(IFormatProvider provider) {}
-    public readonly long ToInt64() {}
+    public long ToInt64() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
-    public readonly ulong ToUInt64() {}
+    public ulong ToUInt64() {}
     public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider) {}
-    public readonly bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
-    public readonly bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.3.2.0.

--- a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.1.0)
+// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-4.0.0)
 //   Name: Smdn.Fundamental.UInt24n
-//   AssemblyVersion: 3.1.0.0
-//   InformationalVersion: 3.1.0+d0bc2ff12d7b860e40c08a17db9b68fff731fb10
+//   AssemblyVersion: 4.0.0.0
+//   InformationalVersion: 4.0.0+67b803a21469d1c9d14f260a6414b9e666a8e282
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -18,7 +18,7 @@ using Smdn;
 namespace Smdn {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
-  public struct UInt24 :
+  public readonly struct UInt24 :
     IBinaryInteger<UInt24>,
     IComparable<int>,
     IComparable<uint>,
@@ -148,13 +148,6 @@ namespace Smdn {
     public static UInt24 operator + (UInt24 @value) {}
     public static UInt24 operator >>> (UInt24 @value, int shiftAmount) {}
 
-    [FieldOffset(0)]
-    public byte Byte0;
-    [FieldOffset(1)]
-    public byte Byte1;
-    [FieldOffset(2)]
-    public byte Byte2;
-
     public UInt24(ReadOnlySpan<byte> @value, bool isBigEndian = false) {}
     public UInt24(byte[] @value, bool isBigEndian = false) {}
     public UInt24(byte[] @value, int startIndex, bool isBigEndian = false) {}
@@ -167,40 +160,40 @@ namespace Smdn {
     public bool Equals(int other) {}
     public bool Equals(uint other) {}
     public override bool Equals(object obj) {}
-    public override readonly int GetHashCode() {}
+    public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
-    readonly byte IConvertible.ToByte(IFormatProvider provider) {}
+    byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
     short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
-    readonly long IConvertible.ToInt64(IFormatProvider provider) {}
-    readonly sbyte IConvertible.ToSByte(IFormatProvider provider) {}
+    long IConvertible.ToInt64(IFormatProvider provider) {}
+    sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
     ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
-    readonly ulong IConvertible.ToUInt64(IFormatProvider provider) {}
+    ulong IConvertible.ToUInt64(IFormatProvider provider) {}
     int IBinaryInteger<UInt24>.GetByteCount() {}
     int IBinaryInteger<UInt24>.GetShortestBitLength() {}
-    public readonly int ToInt32() {}
+    public int ToInt32() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
-    public readonly uint ToUInt32() {}
+    public uint ToUInt32() {}
     public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider) {}
-    public readonly bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
-    public readonly bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
-  public struct UInt48 :
+  public readonly struct UInt48 :
     IBinaryInteger<UInt48>,
     IComparable<long>,
     IComparable<ulong>,
@@ -330,19 +323,6 @@ namespace Smdn {
     public static UInt48 operator + (UInt48 @value) {}
     public static UInt48 operator >>> (UInt48 @value, int shiftAmount) {}
 
-    [FieldOffset(0)]
-    public byte Byte0;
-    [FieldOffset(1)]
-    public byte Byte1;
-    [FieldOffset(2)]
-    public byte Byte2;
-    [FieldOffset(3)]
-    public byte Byte3;
-    [FieldOffset(4)]
-    public byte Byte4;
-    [FieldOffset(5)]
-    public byte Byte5;
-
     public UInt48(ReadOnlySpan<byte> @value, bool isBigEndian = false) {}
     public UInt48(byte[] @value, bool isBigEndian = false) {}
     public UInt48(byte[] @value, int startIndex, bool isBigEndian = false) {}
@@ -355,35 +335,35 @@ namespace Smdn {
     public bool Equals(long other) {}
     public bool Equals(ulong other) {}
     public override bool Equals(object obj) {}
-    public override readonly int GetHashCode() {}
+    public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
-    readonly byte IConvertible.ToByte(IFormatProvider provider) {}
+    byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
-    readonly short IConvertible.ToInt16(IFormatProvider provider) {}
+    short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
     long IConvertible.ToInt64(IFormatProvider provider) {}
-    readonly sbyte IConvertible.ToSByte(IFormatProvider provider) {}
+    sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
-    readonly ushort IConvertible.ToUInt16(IFormatProvider provider) {}
+    ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
     ulong IConvertible.ToUInt64(IFormatProvider provider) {}
     int IBinaryInteger<UInt48>.GetByteCount() {}
     int IBinaryInteger<UInt48>.GetShortestBitLength() {}
-    public readonly long ToInt64() {}
+    public long ToInt64() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
-    public readonly ulong ToUInt64() {}
+    public ulong ToUInt64() {}
     public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider) {}
-    public readonly bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
-    public readonly bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.3.2.0.

--- a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard1.6.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.1.0)
+// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-4.0.0)
 //   Name: Smdn.Fundamental.UInt24n
-//   AssemblyVersion: 3.1.0.0
-//   InformationalVersion: 3.1.0+d0bc2ff12d7b860e40c08a17db9b68fff731fb10
+//   AssemblyVersion: 4.0.0.0
+//   InformationalVersion: 4.0.0+67b803a21469d1c9d14f260a6414b9e666a8e282
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 //   Referenced assemblies:
@@ -20,7 +20,7 @@ using Smdn;
 namespace Smdn {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
-  public struct UInt24 :
+  public readonly struct UInt24 :
     IComparable,
     IComparable<UInt24>,
     IComparable<int>,
@@ -100,13 +100,6 @@ namespace Smdn {
     public static UInt24 operator + (UInt24 @value) {}
     public static UInt24 operator >>> (UInt24 @value, int shiftAmount) {}
 
-    [FieldOffset(0)]
-    public byte Byte0;
-    [FieldOffset(1)]
-    public byte Byte1;
-    [FieldOffset(2)]
-    public byte Byte2;
-
     public UInt24(ReadOnlySpan<byte> @value, bool isBigEndian = false) {}
     public UInt24(byte[] @value, bool isBigEndian = false) {}
     public UInt24(byte[] @value, int startIndex, bool isBigEndian = false) {}
@@ -119,37 +112,37 @@ namespace Smdn {
     public bool Equals(int other) {}
     public bool Equals(uint other) {}
     public override bool Equals(object obj) {}
-    public override readonly int GetHashCode() {}
+    public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
-    readonly byte IConvertible.ToByte(IFormatProvider provider) {}
+    byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
     short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
-    readonly long IConvertible.ToInt64(IFormatProvider provider) {}
-    readonly sbyte IConvertible.ToSByte(IFormatProvider provider) {}
+    long IConvertible.ToInt64(IFormatProvider provider) {}
+    sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
     ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
-    readonly ulong IConvertible.ToUInt64(IFormatProvider provider) {}
-    public readonly int ToInt32() {}
+    ulong IConvertible.ToUInt64(IFormatProvider provider) {}
+    public int ToInt32() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
-    public readonly uint ToUInt32() {}
-    public readonly bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
-    public readonly bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
+    public uint ToUInt32() {}
+    public bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
-  public struct UInt48 :
+  public readonly struct UInt48 :
     IComparable,
     IComparable<UInt48>,
     IComparable<long>,
@@ -229,19 +222,6 @@ namespace Smdn {
     public static UInt48 operator + (UInt48 @value) {}
     public static UInt48 operator >>> (UInt48 @value, int shiftAmount) {}
 
-    [FieldOffset(0)]
-    public byte Byte0;
-    [FieldOffset(1)]
-    public byte Byte1;
-    [FieldOffset(2)]
-    public byte Byte2;
-    [FieldOffset(3)]
-    public byte Byte3;
-    [FieldOffset(4)]
-    public byte Byte4;
-    [FieldOffset(5)]
-    public byte Byte5;
-
     public UInt48(ReadOnlySpan<byte> @value, bool isBigEndian = false) {}
     public UInt48(byte[] @value, bool isBigEndian = false) {}
     public UInt48(byte[] @value, int startIndex, bool isBigEndian = false) {}
@@ -254,32 +234,32 @@ namespace Smdn {
     public bool Equals(long other) {}
     public bool Equals(ulong other) {}
     public override bool Equals(object obj) {}
-    public override readonly int GetHashCode() {}
+    public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
-    readonly byte IConvertible.ToByte(IFormatProvider provider) {}
+    byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
-    readonly short IConvertible.ToInt16(IFormatProvider provider) {}
+    short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
     long IConvertible.ToInt64(IFormatProvider provider) {}
-    readonly sbyte IConvertible.ToSByte(IFormatProvider provider) {}
+    sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
-    readonly ushort IConvertible.ToUInt16(IFormatProvider provider) {}
+    ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
     ulong IConvertible.ToUInt64(IFormatProvider provider) {}
-    public readonly long ToInt64() {}
+    public long ToInt64() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
-    public readonly ulong ToUInt64() {}
-    public readonly bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
-    public readonly bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
+    public ulong ToUInt64() {}
+    public bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.3.2.0.

--- a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard2.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.1.0)
+// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-4.0.0)
 //   Name: Smdn.Fundamental.UInt24n
-//   AssemblyVersion: 3.1.0.0
-//   InformationalVersion: 3.1.0+d0bc2ff12d7b860e40c08a17db9b68fff731fb10
+//   AssemblyVersion: 4.0.0.0
+//   InformationalVersion: 4.0.0+67b803a21469d1c9d14f260a6414b9e666a8e282
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -17,7 +17,7 @@ using Smdn;
 namespace Smdn {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
-  public struct UInt24 :
+  public readonly struct UInt24 :
     IComparable,
     IComparable<UInt24>,
     IComparable<int>,
@@ -97,13 +97,6 @@ namespace Smdn {
     public static UInt24 operator + (UInt24 @value) {}
     public static UInt24 operator >>> (UInt24 @value, int shiftAmount) {}
 
-    [FieldOffset(0)]
-    public byte Byte0;
-    [FieldOffset(1)]
-    public byte Byte1;
-    [FieldOffset(2)]
-    public byte Byte2;
-
     public UInt24(ReadOnlySpan<byte> @value, bool isBigEndian = false) {}
     public UInt24(byte[] @value, bool isBigEndian = false) {}
     public UInt24(byte[] @value, int startIndex, bool isBigEndian = false) {}
@@ -116,37 +109,37 @@ namespace Smdn {
     public bool Equals(int other) {}
     public bool Equals(uint other) {}
     public override bool Equals(object obj) {}
-    public override readonly int GetHashCode() {}
+    public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
-    readonly byte IConvertible.ToByte(IFormatProvider provider) {}
+    byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
     short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
-    readonly long IConvertible.ToInt64(IFormatProvider provider) {}
-    readonly sbyte IConvertible.ToSByte(IFormatProvider provider) {}
+    long IConvertible.ToInt64(IFormatProvider provider) {}
+    sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
     ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
-    readonly ulong IConvertible.ToUInt64(IFormatProvider provider) {}
-    public readonly int ToInt32() {}
+    ulong IConvertible.ToUInt64(IFormatProvider provider) {}
+    public int ToInt32() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
-    public readonly uint ToUInt32() {}
-    public readonly bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
-    public readonly bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
+    public uint ToUInt32() {}
+    public bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
-  public struct UInt48 :
+  public readonly struct UInt48 :
     IComparable,
     IComparable<UInt48>,
     IComparable<long>,
@@ -226,19 +219,6 @@ namespace Smdn {
     public static UInt48 operator + (UInt48 @value) {}
     public static UInt48 operator >>> (UInt48 @value, int shiftAmount) {}
 
-    [FieldOffset(0)]
-    public byte Byte0;
-    [FieldOffset(1)]
-    public byte Byte1;
-    [FieldOffset(2)]
-    public byte Byte2;
-    [FieldOffset(3)]
-    public byte Byte3;
-    [FieldOffset(4)]
-    public byte Byte4;
-    [FieldOffset(5)]
-    public byte Byte5;
-
     public UInt48(ReadOnlySpan<byte> @value, bool isBigEndian = false) {}
     public UInt48(byte[] @value, bool isBigEndian = false) {}
     public UInt48(byte[] @value, int startIndex, bool isBigEndian = false) {}
@@ -251,32 +231,32 @@ namespace Smdn {
     public bool Equals(long other) {}
     public bool Equals(ulong other) {}
     public override bool Equals(object obj) {}
-    public override readonly int GetHashCode() {}
+    public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
-    readonly byte IConvertible.ToByte(IFormatProvider provider) {}
+    byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
-    readonly short IConvertible.ToInt16(IFormatProvider provider) {}
+    short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
     long IConvertible.ToInt64(IFormatProvider provider) {}
-    readonly sbyte IConvertible.ToSByte(IFormatProvider provider) {}
+    sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
-    readonly ushort IConvertible.ToUInt16(IFormatProvider provider) {}
+    ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
     ulong IConvertible.ToUInt64(IFormatProvider provider) {}
-    public readonly long ToInt64() {}
+    public long ToInt64() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
-    public readonly ulong ToUInt64() {}
-    public readonly bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
-    public readonly bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
+    public ulong ToUInt64() {}
+    public bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.3.2.0.

--- a/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.UInt24n/Smdn.Fundamental.UInt24n-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-3.1.0)
+// Smdn.Fundamental.UInt24n.dll (Smdn.Fundamental.UInt24n-4.0.0)
 //   Name: Smdn.Fundamental.UInt24n
-//   AssemblyVersion: 3.1.0.0
-//   InformationalVersion: 3.1.0+d0bc2ff12d7b860e40c08a17db9b68fff731fb10
+//   AssemblyVersion: 4.0.0.0
+//   InformationalVersion: 4.0.0+67b803a21469d1c9d14f260a6414b9e666a8e282
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -17,7 +17,7 @@ using Smdn;
 namespace Smdn {
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
-  public struct UInt24 :
+  public readonly struct UInt24 :
     IComparable,
     IComparable<UInt24>,
     IComparable<int>,
@@ -101,13 +101,6 @@ namespace Smdn {
     public static UInt24 operator + (UInt24 @value) {}
     public static UInt24 operator >>> (UInt24 @value, int shiftAmount) {}
 
-    [FieldOffset(0)]
-    public byte Byte0;
-    [FieldOffset(1)]
-    public byte Byte1;
-    [FieldOffset(2)]
-    public byte Byte2;
-
     public UInt24(ReadOnlySpan<byte> @value, bool isBigEndian = false) {}
     public UInt24(byte[] @value, bool isBigEndian = false) {}
     public UInt24(byte[] @value, int startIndex, bool isBigEndian = false) {}
@@ -120,37 +113,37 @@ namespace Smdn {
     public bool Equals(int other) {}
     public bool Equals(uint other) {}
     public override bool Equals(object obj) {}
-    public override readonly int GetHashCode() {}
+    public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
-    readonly byte IConvertible.ToByte(IFormatProvider provider) {}
+    byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
     short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
-    readonly long IConvertible.ToInt64(IFormatProvider provider) {}
-    readonly sbyte IConvertible.ToSByte(IFormatProvider provider) {}
+    long IConvertible.ToInt64(IFormatProvider provider) {}
+    sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
     ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
-    readonly ulong IConvertible.ToUInt64(IFormatProvider provider) {}
-    public readonly int ToInt32() {}
+    ulong IConvertible.ToUInt64(IFormatProvider provider) {}
+    public int ToInt32() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
-    public readonly uint ToUInt32() {}
-    public readonly bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
-    public readonly bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
+    public uint ToUInt32() {}
+    public bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
   }
 
   [TypeForwardedFrom("Smdn, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null")]
   [StructLayout(LayoutKind.Explicit, Pack = 1)]
-  public struct UInt48 :
+  public readonly struct UInt48 :
     IComparable,
     IComparable<UInt48>,
     IComparable<long>,
@@ -234,19 +227,6 @@ namespace Smdn {
     public static UInt48 operator + (UInt48 @value) {}
     public static UInt48 operator >>> (UInt48 @value, int shiftAmount) {}
 
-    [FieldOffset(0)]
-    public byte Byte0;
-    [FieldOffset(1)]
-    public byte Byte1;
-    [FieldOffset(2)]
-    public byte Byte2;
-    [FieldOffset(3)]
-    public byte Byte3;
-    [FieldOffset(4)]
-    public byte Byte4;
-    [FieldOffset(5)]
-    public byte Byte5;
-
     public UInt48(ReadOnlySpan<byte> @value, bool isBigEndian = false) {}
     public UInt48(byte[] @value, bool isBigEndian = false) {}
     public UInt48(byte[] @value, int startIndex, bool isBigEndian = false) {}
@@ -259,32 +239,32 @@ namespace Smdn {
     public bool Equals(long other) {}
     public bool Equals(ulong other) {}
     public override bool Equals(object obj) {}
-    public override readonly int GetHashCode() {}
+    public override int GetHashCode() {}
     TypeCode IConvertible.GetTypeCode() {}
     bool IConvertible.ToBoolean(IFormatProvider provider) {}
-    readonly byte IConvertible.ToByte(IFormatProvider provider) {}
+    byte IConvertible.ToByte(IFormatProvider provider) {}
     char IConvertible.ToChar(IFormatProvider provider) {}
     DateTime IConvertible.ToDateTime(IFormatProvider provider) {}
     decimal IConvertible.ToDecimal(IFormatProvider provider) {}
     double IConvertible.ToDouble(IFormatProvider provider) {}
-    readonly short IConvertible.ToInt16(IFormatProvider provider) {}
+    short IConvertible.ToInt16(IFormatProvider provider) {}
     int IConvertible.ToInt32(IFormatProvider provider) {}
     long IConvertible.ToInt64(IFormatProvider provider) {}
-    readonly sbyte IConvertible.ToSByte(IFormatProvider provider) {}
+    sbyte IConvertible.ToSByte(IFormatProvider provider) {}
     float IConvertible.ToSingle(IFormatProvider provider) {}
     string IConvertible.ToString(IFormatProvider provider) {}
     object IConvertible.ToType(Type conversionType, IFormatProvider provider) {}
-    readonly ushort IConvertible.ToUInt16(IFormatProvider provider) {}
+    ushort IConvertible.ToUInt16(IFormatProvider provider) {}
     uint IConvertible.ToUInt32(IFormatProvider provider) {}
     ulong IConvertible.ToUInt64(IFormatProvider provider) {}
-    public readonly long ToInt64() {}
+    public long ToInt64() {}
     public override string ToString() {}
     public string ToString(IFormatProvider formatProvider) {}
     public string ToString(string format) {}
     public string ToString(string format, IFormatProvider formatProvider) {}
-    public readonly ulong ToUInt64() {}
-    public readonly bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
-    public readonly bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
+    public ulong ToUInt64() {}
+    public bool TryWriteBigEndian(Span<byte> destination, out int bytesWritten) {}
+    public bool TryWriteLittleEndian(Span<byte> destination, out int bytesWritten) {}
   }
 }
 // API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.3.2.0.


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #278](https://github.com/smdn/Smdn.Fundamentals/actions/runs/7339727242).

# Release target
- package_target_tag: `new-release/main/Smdn.Fundamental.UInt24n-4.0.0`
- package_prevver_ref: `releases/Smdn.Fundamental.UInt24n-3.1.0`
- package_prevver_tag: `releases/Smdn.Fundamental.UInt24n-3.1.0`
- package_id: `Smdn.Fundamental.UInt24n`
- package_id_with_version: `Smdn.Fundamental.UInt24n-4.0.0`
- package_version: `4.0.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.UInt24n-4.0.0-1703691288`
- release_tag: `releases/Smdn.Fundamental.UInt24n-4.0.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/04b9c2e9e2e4f32cfe4d722d4733f4f9`](https://gist.github.com/smdn/04b9c2e9e2e4f32cfe4d722d4733f4f9)
- artifact_name_nupkg: `Smdn.Fundamental.UInt24n.4.0.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Fundamental.UInt24n.latest.nuspec
+++ Smdn.Fundamental.UInt24n.4.0.0.nuspec
@@ -1,49 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Fundamental.UInt24n</id>
-    <version>3.1.0</version>
+    <version>4.0.0</version>
     <title>Smdn.Fundamental.UInt24n</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Fundamental.UInt24n.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
     <description>Provides 24-bit and 48-bit unsigned integer types, `UInt24` and `UInt48`. These types are compatible with the generic math functionality since they implement the IUnsignedNumber&lt;TSelf&gt; and other generic math interfaces.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Fundamentals/releases/tag/releases%2FSmdn.Fundamental.UInt24n-3.1.0</releaseNotes>
+    <releaseNotes>https://github.com/smdn/Smdn.Fundamentals/releases/tag/releases%2FSmdn.Fundamental.UInt24n-4.0.0</releaseNotes>
     <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp uint24 uint48 24bit 48bit interger</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="d0bc2ff12d7b860e40c08a17db9b68fff731fb10" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" commit="67b803a21469d1c9d14f260a6414b9e666a8e282" />
     <dependencies>
       <group targetFramework=".NETFramework4.5">
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Shim" version="[3.1.4, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
         <dependency id="System.ValueTuple" version="4.5.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard1.6">
         <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Shim" version="[3.1.4, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
         <dependency id="System.ValueTuple" version="4.5.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net6.0">
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Shim" version="[3.1.4, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Shim" version="[3.1.4, 4.0.0)" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/net45/Smdn.Fundamental.UInt24n.dll" target="lib/net45/Smdn.Fundamental.UInt24n.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/net45/Smdn.Fundamental.UInt24n.xml" target="lib/net45/Smdn.Fundamental.UInt24n.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/net6.0/Smdn.Fundamental.UInt24n.dll" target="lib/net6.0/Smdn.Fundamental.UInt24n.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/net6.0/Smdn.Fundamental.UInt24n.xml" target="lib/net6.0/Smdn.Fundamental.UInt24n.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/net8.0/Smdn.Fundamental.UInt24n.dll" target="lib/net8.0/Smdn.Fundamental.UInt24n.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/net8.0/Smdn.Fundamental.UInt24n.xml" target="lib/net8.0/Smdn.Fundamental.UInt24n.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/netstandard1.6/Smdn.Fundamental.UInt24n.dll" target="lib/netstandard1.6/Smdn.Fundamental.UInt24n.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/netstandard1.6/Smdn.Fundamental.UInt24n.xml" target="lib/netstandard1.6/Smdn.Fundamental.UInt24n.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/netstandard2.0/Smdn.Fundamental.UInt24n.dll" target="lib/netstandard2.0/Smdn.Fundamental.UInt24n.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/netstandard2.0/Smdn.Fundamental.UInt24n.xml" target="lib/netstandard2.0/Smdn.Fundamental.UInt24n.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/netstandard2.1/Smdn.Fundamental.UInt24n.dll" target="lib/netstandard2.1/Smdn.Fundamental.UInt24n.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/netstandard2.1/Smdn.Fundamental.UInt24n.xml" target="lib/netstandard2.1/Smdn.Fundamental.UInt24n.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.Fundamental.UInt24n.png" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.UInt24n/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

