### PR TITLE
Release main/Smdn.Fundamental.Uuid-3.2.0

### DIFF
--- a/doc/api-list/Smdn.Fundamental.Uuid/Smdn.Fundamental.Uuid-net45.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Uuid/Smdn.Fundamental.Uuid-net45.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Uuid.dll (Smdn.Fundamental.Uuid-3.1.1)
+// Smdn.Fundamental.Uuid.dll (Smdn.Fundamental.Uuid-3.2.0)
 //   Name: Smdn.Fundamental.Uuid
-//   AssemblyVersion: 3.1.1.0
-//   InformationalVersion: 3.1.1+b57b4cba29f01d9537ede2ca39db9abb783b20da
+//   AssemblyVersion: 3.2.0.0
+//   InformationalVersion: 3.2.0+7357848de1363dbe011b04607e6d6f97dd2b4e57
 //   TargetFramework: .NETFramework,Version=v4.5
 //   Configuration: Release
 //   Referenced assemblies:
@@ -12,6 +12,7 @@
 //     System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
+#nullable enable annotations
 
 using System;
 using System.Net.NetworkInformation;
@@ -90,11 +91,11 @@ namespace Smdn {
     public static Uuid CreateTimeBased(PhysicalAddress node) {}
     public static Uuid CreateTimeBased(byte[] node) {}
     public static Uuid NewUuid() {}
-    public static Uuid Parse(ReadOnlySpan<char> s, IFormatProvider provider = null) {}
-    public static Uuid Parse(string s, IFormatProvider provider = null) {}
-    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider provider, out Uuid result) {}
+    public static Uuid Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null) {}
+    public static Uuid Parse(string s, IFormatProvider? provider = null) {}
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Uuid result) {}
     public static bool TryParse(ReadOnlySpan<char> s, out Uuid result) {}
-    public static bool TryParse(string s, IFormatProvider provider, out Uuid result) {}
+    public static bool TryParse(string? s, IFormatProvider? provider, out Uuid result) {}
     public static bool operator == (Uuid x, Uuid y) {}
     public static explicit operator Guid(Uuid @value) {}
     public static explicit operator Uuid(Guid @value) {}
@@ -131,10 +132,10 @@ namespace Smdn {
 
     public int CompareTo(Guid other) {}
     public int CompareTo(Uuid other) {}
-    public int CompareTo(object obj) {}
+    public int CompareTo(object? obj) {}
     public bool Equals(Guid other) {}
     public bool Equals(Uuid other) {}
-    public override bool Equals(object obj) {}
+    public override bool Equals(object? obj) {}
     public void GetBytes(byte[] buffer, int startIndex) {}
     public void GetBytes(byte[] buffer, int startIndex, bool asBigEndian) {}
     public override int GetHashCode() {}
@@ -143,8 +144,8 @@ namespace Smdn {
     public Guid ToGuid() {}
     public override string ToString() {}
     public string ToString(string format) {}
-    public string ToString(string format, IFormatProvider formatProvider) {}
-    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null) {}
+    public string ToString(string? format, IFormatProvider? formatProvider) {}
+    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null) {}
     public bool TryWriteBytes(Span<byte> destination, bool asBigEndian) {}
     public void WriteBytes(Span<byte> destination, bool asBigEndian) {}
   }
@@ -179,12 +180,12 @@ namespace Smdn.Formats.UniversallyUniqueIdentifiers {
     IFormattable
   {
     public static Node CreateRandom() {}
-    public static Node Parse(ReadOnlySpan<char> s, IFormatProvider provider = null) {}
-    public static Node Parse(string s, IFormatProvider provider = null) {}
-    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider provider, out Node result) {}
+    public static Node Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null) {}
+    public static Node Parse(string s, IFormatProvider? provider = null) {}
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Node result) {}
     public static bool TryParse(ReadOnlySpan<char> s, out Node result) {}
-    public static bool TryParse(string s, IFormatProvider provider, out Node result) {}
-    public static bool TryParse(string s, out Node result) {}
+    public static bool TryParse(string? s, IFormatProvider? provider, out Node result) {}
+    public static bool TryParse(string? s, out Node result) {}
     public static bool operator == (Node x, Node y) {}
     public static bool operator > (Node x, Node y) {}
     public static bool operator >= (Node x, Node y) {}
@@ -195,16 +196,16 @@ namespace Smdn.Formats.UniversallyUniqueIdentifiers {
     public Node(PhysicalAddress physicalAddress) {}
 
     public int CompareTo(Node other) {}
-    public int CompareTo(object obj) {}
+    public int CompareTo(object? obj) {}
     public bool Equals(Node other) {}
-    public override bool Equals(object obj) {}
+    public override bool Equals(object? obj) {}
     public override int GetHashCode() {}
     public PhysicalAddress ToPhysicalAddress() {}
     public override string ToString() {}
-    public string ToString(string format, IFormatProvider formatProvider = null) {}
+    public string ToString(string? format, IFormatProvider? formatProvider = null) {}
     public bool TryWriteBytes(Span<byte> destination) {}
     public void WriteBytes(Span<byte> destination) {}
   }
 }
-// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.2.0.0.
+// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.3.2.0.
 // Smdn.Reflection.ReverseGenerating.ListApi.Core v1.2.0.0 (https://github.com/smdn/Smdn.Reflection.ReverseGenerating)

--- a/doc/api-list/Smdn.Fundamental.Uuid/Smdn.Fundamental.Uuid-net461.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Uuid/Smdn.Fundamental.Uuid-net461.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Uuid.dll (Smdn.Fundamental.Uuid-3.1.1)
+// Smdn.Fundamental.Uuid.dll (Smdn.Fundamental.Uuid-3.2.0)
 //   Name: Smdn.Fundamental.Uuid
-//   AssemblyVersion: 3.1.1.0
-//   InformationalVersion: 3.1.1+b57b4cba29f01d9537ede2ca39db9abb783b20da
+//   AssemblyVersion: 3.2.0.0
+//   InformationalVersion: 3.2.0+7357848de1363dbe011b04607e6d6f97dd2b4e57
 //   TargetFramework: .NETFramework,Version=v4.6.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -13,6 +13,7 @@
 //     System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
+#nullable enable annotations
 
 using System;
 using System.Net.NetworkInformation;
@@ -91,11 +92,11 @@ namespace Smdn {
     public static Uuid CreateTimeBased(PhysicalAddress node) {}
     public static Uuid CreateTimeBased(byte[] node) {}
     public static Uuid NewUuid() {}
-    public static Uuid Parse(ReadOnlySpan<char> s, IFormatProvider provider = null) {}
-    public static Uuid Parse(string s, IFormatProvider provider = null) {}
-    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider provider, out Uuid result) {}
+    public static Uuid Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null) {}
+    public static Uuid Parse(string s, IFormatProvider? provider = null) {}
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Uuid result) {}
     public static bool TryParse(ReadOnlySpan<char> s, out Uuid result) {}
-    public static bool TryParse(string s, IFormatProvider provider, out Uuid result) {}
+    public static bool TryParse(string? s, IFormatProvider? provider, out Uuid result) {}
     public static bool operator == (Uuid x, Uuid y) {}
     public static explicit operator Guid(Uuid @value) {}
     public static explicit operator Uuid(Guid @value) {}
@@ -132,10 +133,10 @@ namespace Smdn {
 
     public int CompareTo(Guid other) {}
     public int CompareTo(Uuid other) {}
-    public int CompareTo(object obj) {}
+    public int CompareTo(object? obj) {}
     public bool Equals(Guid other) {}
     public bool Equals(Uuid other) {}
-    public override bool Equals(object obj) {}
+    public override bool Equals(object? obj) {}
     public void GetBytes(byte[] buffer, int startIndex) {}
     public void GetBytes(byte[] buffer, int startIndex, bool asBigEndian) {}
     public override int GetHashCode() {}
@@ -144,8 +145,8 @@ namespace Smdn {
     public Guid ToGuid() {}
     public override string ToString() {}
     public string ToString(string format) {}
-    public string ToString(string format, IFormatProvider formatProvider) {}
-    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null) {}
+    public string ToString(string? format, IFormatProvider? formatProvider) {}
+    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null) {}
     public bool TryWriteBytes(Span<byte> destination, bool asBigEndian) {}
     public void WriteBytes(Span<byte> destination, bool asBigEndian) {}
   }
@@ -180,12 +181,12 @@ namespace Smdn.Formats.UniversallyUniqueIdentifiers {
     IFormattable
   {
     public static Node CreateRandom() {}
-    public static Node Parse(ReadOnlySpan<char> s, IFormatProvider provider = null) {}
-    public static Node Parse(string s, IFormatProvider provider = null) {}
-    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider provider, out Node result) {}
+    public static Node Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null) {}
+    public static Node Parse(string s, IFormatProvider? provider = null) {}
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Node result) {}
     public static bool TryParse(ReadOnlySpan<char> s, out Node result) {}
-    public static bool TryParse(string s, IFormatProvider provider, out Node result) {}
-    public static bool TryParse(string s, out Node result) {}
+    public static bool TryParse(string? s, IFormatProvider? provider, out Node result) {}
+    public static bool TryParse(string? s, out Node result) {}
     public static bool operator == (Node x, Node y) {}
     public static bool operator > (Node x, Node y) {}
     public static bool operator >= (Node x, Node y) {}
@@ -196,16 +197,16 @@ namespace Smdn.Formats.UniversallyUniqueIdentifiers {
     public Node(PhysicalAddress physicalAddress) {}
 
     public int CompareTo(Node other) {}
-    public int CompareTo(object obj) {}
+    public int CompareTo(object? obj) {}
     public bool Equals(Node other) {}
-    public override bool Equals(object obj) {}
+    public override bool Equals(object? obj) {}
     public override int GetHashCode() {}
     public PhysicalAddress ToPhysicalAddress() {}
     public override string ToString() {}
-    public string ToString(string format, IFormatProvider formatProvider = null) {}
+    public string ToString(string? format, IFormatProvider? formatProvider = null) {}
     public bool TryWriteBytes(Span<byte> destination) {}
     public void WriteBytes(Span<byte> destination) {}
   }
 }
-// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.2.0.0.
+// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.3.2.0.
 // Smdn.Reflection.ReverseGenerating.ListApi.Core v1.2.0.0 (https://github.com/smdn/Smdn.Reflection.ReverseGenerating)

--- a/doc/api-list/Smdn.Fundamental.Uuid/Smdn.Fundamental.Uuid-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Uuid/Smdn.Fundamental.Uuid-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Uuid.dll (Smdn.Fundamental.Uuid-3.1.1)
+// Smdn.Fundamental.Uuid.dll (Smdn.Fundamental.Uuid-3.2.0)
 //   Name: Smdn.Fundamental.Uuid
-//   AssemblyVersion: 3.1.1.0
-//   InformationalVersion: 3.1.1+b57b4cba29f01d9537ede2ca39db9abb783b20da
+//   AssemblyVersion: 3.2.0.0
+//   InformationalVersion: 3.2.0+7357848de1363dbe011b04607e6d6f97dd2b4e57
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -12,6 +12,7 @@
 //     System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Security.Cryptography.Algorithms, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Security.Cryptography.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+#nullable enable annotations
 
 using System;
 using System.Net.NetworkInformation;
@@ -90,11 +91,11 @@ namespace Smdn {
     public static Uuid CreateTimeBased(PhysicalAddress node) {}
     public static Uuid CreateTimeBased(byte[] node) {}
     public static Uuid NewUuid() {}
-    public static Uuid Parse(ReadOnlySpan<char> s, IFormatProvider provider = null) {}
-    public static Uuid Parse(string s, IFormatProvider provider = null) {}
-    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider provider, out Uuid result) {}
+    public static Uuid Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null) {}
+    public static Uuid Parse(string s, IFormatProvider? provider = null) {}
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Uuid result) {}
     public static bool TryParse(ReadOnlySpan<char> s, out Uuid result) {}
-    public static bool TryParse(string s, IFormatProvider provider, out Uuid result) {}
+    public static bool TryParse(string? s, IFormatProvider? provider, out Uuid result) {}
     public static bool operator == (Uuid x, Uuid y) {}
     public static explicit operator Guid(Uuid @value) {}
     public static explicit operator Uuid(Guid @value) {}
@@ -131,10 +132,10 @@ namespace Smdn {
 
     public int CompareTo(Guid other) {}
     public int CompareTo(Uuid other) {}
-    public int CompareTo(object obj) {}
+    public int CompareTo(object? obj) {}
     public bool Equals(Guid other) {}
     public bool Equals(Uuid other) {}
-    public override bool Equals(object obj) {}
+    public override bool Equals(object? obj) {}
     public void GetBytes(byte[] buffer, int startIndex) {}
     public void GetBytes(byte[] buffer, int startIndex, bool asBigEndian) {}
     public override int GetHashCode() {}
@@ -143,8 +144,8 @@ namespace Smdn {
     public Guid ToGuid() {}
     public override string ToString() {}
     public string ToString(string format) {}
-    public string ToString(string format, IFormatProvider formatProvider) {}
-    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null) {}
+    public string ToString(string? format, IFormatProvider? formatProvider) {}
+    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null) {}
     public bool TryWriteBytes(Span<byte> destination, bool asBigEndian) {}
     public void WriteBytes(Span<byte> destination, bool asBigEndian) {}
   }
@@ -179,12 +180,12 @@ namespace Smdn.Formats.UniversallyUniqueIdentifiers {
     ISpanFormattable
   {
     public static Node CreateRandom() {}
-    public static Node Parse(ReadOnlySpan<char> s, IFormatProvider provider = null) {}
-    public static Node Parse(string s, IFormatProvider provider = null) {}
-    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider provider, out Node result) {}
+    public static Node Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null) {}
+    public static Node Parse(string s, IFormatProvider? provider = null) {}
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Node result) {}
     public static bool TryParse(ReadOnlySpan<char> s, out Node result) {}
-    public static bool TryParse(string s, IFormatProvider provider, out Node result) {}
-    public static bool TryParse(string s, out Node result) {}
+    public static bool TryParse(string? s, IFormatProvider? provider, out Node result) {}
+    public static bool TryParse(string? s, out Node result) {}
     public static bool operator == (Node x, Node y) {}
     public static bool operator > (Node x, Node y) {}
     public static bool operator >= (Node x, Node y) {}
@@ -195,17 +196,17 @@ namespace Smdn.Formats.UniversallyUniqueIdentifiers {
     public Node(PhysicalAddress physicalAddress) {}
 
     public int CompareTo(Node other) {}
-    public int CompareTo(object obj) {}
+    public int CompareTo(object? obj) {}
     public bool Equals(Node other) {}
-    public override bool Equals(object obj) {}
+    public override bool Equals(object? obj) {}
     public override int GetHashCode() {}
     public PhysicalAddress ToPhysicalAddress() {}
     public override string ToString() {}
-    public string ToString(string format, IFormatProvider formatProvider = null) {}
-    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider) {}
+    public string ToString(string? format, IFormatProvider? formatProvider = null) {}
+    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider) {}
     public bool TryWriteBytes(Span<byte> destination) {}
     public void WriteBytes(Span<byte> destination) {}
   }
 }
-// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.2.0.0.
+// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.3.2.0.
 // Smdn.Reflection.ReverseGenerating.ListApi.Core v1.2.0.0 (https://github.com/smdn/Smdn.Reflection.ReverseGenerating)

--- a/doc/api-list/Smdn.Fundamental.Uuid/Smdn.Fundamental.Uuid-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Uuid/Smdn.Fundamental.Uuid-net8.0.apilist.cs
@@ -2,19 +2,19 @@
 //   Name: Smdn.Fundamental.Uuid
 //   AssemblyVersion: 3.2.0.0
 //   InformationalVersion: 3.2.0+7357848de1363dbe011b04607e6d6f97dd2b4e57
-//   TargetFramework: .NETStandard,Version=v2.0
+//   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
-//     Microsoft.Bcl.HashCode, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     Smdn.Fundamental.Exception, Version=3.0.3.0, Culture=neutral
-//     Smdn.Fundamental.Shim, Version=3.1.4.0, Culture=neutral
-//     System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
-//     System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
-//     netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+//     System.Memory, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+//     System.Net.NetworkInformation, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Security.Cryptography, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 #nullable enable annotations
 
 using System;
 using System.Net.NetworkInformation;
+using System.Numerics;
 using System.Security.Cryptography;
 using Smdn;
 using Smdn.Formats.UniversallyUniqueIdentifiers;
@@ -40,9 +40,11 @@ namespace Smdn {
     IComparable,
     IComparable<Guid>,
     IComparable<Uuid>,
+    IComparisonOperators<Uuid, Uuid, bool>,
     IEquatable<Guid>,
     IEquatable<Uuid>,
-    IFormattable
+    ISpanFormattable,
+    ISpanParsable<Uuid>
   {
     public enum Namespace : int {
       RFC4122Dns = 1806153744,
@@ -175,8 +177,10 @@ namespace Smdn.Formats.UniversallyUniqueIdentifiers {
   public readonly struct Node :
     IComparable,
     IComparable<Node>,
+    IComparisonOperators<Node, Node, bool>,
     IEquatable<Node>,
-    IFormattable
+    ISpanFormattable,
+    ISpanParsable<Node>
   {
     public static Node CreateRandom() {}
     public static Node Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null) {}
@@ -202,6 +206,7 @@ namespace Smdn.Formats.UniversallyUniqueIdentifiers {
     public PhysicalAddress ToPhysicalAddress() {}
     public override string ToString() {}
     public string ToString(string? format, IFormatProvider? formatProvider = null) {}
+    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider) {}
     public bool TryWriteBytes(Span<byte> destination) {}
     public void WriteBytes(Span<byte> destination) {}
   }

--- a/doc/api-list/Smdn.Fundamental.Uuid/Smdn.Fundamental.Uuid-netstandard1.6.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Uuid/Smdn.Fundamental.Uuid-netstandard1.6.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Fundamental.Uuid.dll (Smdn.Fundamental.Uuid-3.1.1)
+// Smdn.Fundamental.Uuid.dll (Smdn.Fundamental.Uuid-3.2.0)
 //   Name: Smdn.Fundamental.Uuid
-//   AssemblyVersion: 3.1.1.0
-//   InformationalVersion: 3.1.1+b57b4cba29f01d9537ede2ca39db9abb783b20da
+//   AssemblyVersion: 3.2.0.0
+//   InformationalVersion: 3.2.0+7357848de1363dbe011b04607e6d6f97dd2b4e57
 //   TargetFramework: .NETStandard,Version=v1.6
 //   Configuration: Release
 //   Referenced assemblies:
@@ -16,6 +16,7 @@
 //     System.Security.Cryptography.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Text.Encoding, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+#nullable enable annotations
 
 using System;
 using System.Security.Cryptography;
@@ -88,11 +89,11 @@ namespace Smdn {
     public static Uuid CreateNameBasedSHA1(string name, Uuid.Namespace ns) {}
     public static Uuid CreateTimeBased(DateTime timestamp, int clock, byte[] node) {}
     public static Uuid CreateTimeBased(byte[] node) {}
-    public static Uuid Parse(ReadOnlySpan<char> s, IFormatProvider provider = null) {}
-    public static Uuid Parse(string s, IFormatProvider provider = null) {}
-    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider provider, out Uuid result) {}
+    public static Uuid Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null) {}
+    public static Uuid Parse(string s, IFormatProvider? provider = null) {}
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Uuid result) {}
     public static bool TryParse(ReadOnlySpan<char> s, out Uuid result) {}
-    public static bool TryParse(string s, IFormatProvider provider, out Uuid result) {}
+    public static bool TryParse(string? s, IFormatProvider? provider, out Uuid result) {}
     public static bool operator == (Uuid x, Uuid y) {}
     public static explicit operator Guid(Uuid @value) {}
     public static explicit operator Uuid(Guid @value) {}
@@ -127,10 +128,10 @@ namespace Smdn {
 
     public int CompareTo(Guid other) {}
     public int CompareTo(Uuid other) {}
-    public int CompareTo(object obj) {}
+    public int CompareTo(object? obj) {}
     public bool Equals(Guid other) {}
     public bool Equals(Uuid other) {}
-    public override bool Equals(object obj) {}
+    public override bool Equals(object? obj) {}
     public void GetBytes(byte[] buffer, int startIndex) {}
     public void GetBytes(byte[] buffer, int startIndex, bool asBigEndian) {}
     public override int GetHashCode() {}
@@ -139,8 +140,8 @@ namespace Smdn {
     public Guid ToGuid() {}
     public override string ToString() {}
     public string ToString(string format) {}
-    public string ToString(string format, IFormatProvider formatProvider) {}
-    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null) {}
+    public string ToString(string? format, IFormatProvider? formatProvider) {}
+    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null) {}
     public bool TryWriteBytes(Span<byte> destination, bool asBigEndian) {}
     public void WriteBytes(Span<byte> destination, bool asBigEndian) {}
   }
@@ -174,12 +175,12 @@ namespace Smdn.Formats.UniversallyUniqueIdentifiers {
     IFormattable
   {
     public static Node CreateRandom() {}
-    public static Node Parse(ReadOnlySpan<char> s, IFormatProvider provider = null) {}
-    public static Node Parse(string s, IFormatProvider provider = null) {}
-    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider provider, out Node result) {}
+    public static Node Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null) {}
+    public static Node Parse(string s, IFormatProvider? provider = null) {}
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Node result) {}
     public static bool TryParse(ReadOnlySpan<char> s, out Node result) {}
-    public static bool TryParse(string s, IFormatProvider provider, out Node result) {}
-    public static bool TryParse(string s, out Node result) {}
+    public static bool TryParse(string? s, IFormatProvider? provider, out Node result) {}
+    public static bool TryParse(string? s, out Node result) {}
     public static bool operator == (Node x, Node y) {}
     public static bool operator > (Node x, Node y) {}
     public static bool operator >= (Node x, Node y) {}
@@ -188,15 +189,15 @@ namespace Smdn.Formats.UniversallyUniqueIdentifiers {
     public static bool operator <= (Node x, Node y) {}
 
     public int CompareTo(Node other) {}
-    public int CompareTo(object obj) {}
+    public int CompareTo(object? obj) {}
     public bool Equals(Node other) {}
-    public override bool Equals(object obj) {}
+    public override bool Equals(object? obj) {}
     public override int GetHashCode() {}
     public override string ToString() {}
-    public string ToString(string format, IFormatProvider formatProvider = null) {}
+    public string ToString(string? format, IFormatProvider? formatProvider = null) {}
     public bool TryWriteBytes(Span<byte> destination) {}
     public void WriteBytes(Span<byte> destination) {}
   }
 }
-// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.2.0.0.
+// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.3.2.0.
 // Smdn.Reflection.ReverseGenerating.ListApi.Core v1.2.0.0 (https://github.com/smdn/Smdn.Reflection.ReverseGenerating)

--- a/doc/api-list/Smdn.Fundamental.Uuid/Smdn.Fundamental.Uuid-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Fundamental.Uuid/Smdn.Fundamental.Uuid-netstandard2.1.apilist.cs
@@ -1,13 +1,14 @@
-// Smdn.Fundamental.Uuid.dll (Smdn.Fundamental.Uuid-3.1.1)
+// Smdn.Fundamental.Uuid.dll (Smdn.Fundamental.Uuid-3.2.0)
 //   Name: Smdn.Fundamental.Uuid
-//   AssemblyVersion: 3.1.1.0
-//   InformationalVersion: 3.1.1+b57b4cba29f01d9537ede2ca39db9abb783b20da
+//   AssemblyVersion: 3.2.0.0
+//   InformationalVersion: 3.2.0+7357848de1363dbe011b04607e6d6f97dd2b4e57
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
 //     Smdn.Fundamental.Exception, Version=3.0.3.0, Culture=neutral
 //     System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+#nullable enable annotations
 
 using System;
 using System.Net.NetworkInformation;
@@ -86,11 +87,11 @@ namespace Smdn {
     public static Uuid CreateTimeBased(PhysicalAddress node) {}
     public static Uuid CreateTimeBased(byte[] node) {}
     public static Uuid NewUuid() {}
-    public static Uuid Parse(ReadOnlySpan<char> s, IFormatProvider provider = null) {}
-    public static Uuid Parse(string s, IFormatProvider provider = null) {}
-    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider provider, out Uuid result) {}
+    public static Uuid Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null) {}
+    public static Uuid Parse(string s, IFormatProvider? provider = null) {}
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Uuid result) {}
     public static bool TryParse(ReadOnlySpan<char> s, out Uuid result) {}
-    public static bool TryParse(string s, IFormatProvider provider, out Uuid result) {}
+    public static bool TryParse(string? s, IFormatProvider? provider, out Uuid result) {}
     public static bool operator == (Uuid x, Uuid y) {}
     public static explicit operator Guid(Uuid @value) {}
     public static explicit operator Uuid(Guid @value) {}
@@ -127,10 +128,10 @@ namespace Smdn {
 
     public int CompareTo(Guid other) {}
     public int CompareTo(Uuid other) {}
-    public int CompareTo(object obj) {}
+    public int CompareTo(object? obj) {}
     public bool Equals(Guid other) {}
     public bool Equals(Uuid other) {}
-    public override bool Equals(object obj) {}
+    public override bool Equals(object? obj) {}
     public void GetBytes(byte[] buffer, int startIndex) {}
     public void GetBytes(byte[] buffer, int startIndex, bool asBigEndian) {}
     public override int GetHashCode() {}
@@ -139,8 +140,8 @@ namespace Smdn {
     public Guid ToGuid() {}
     public override string ToString() {}
     public string ToString(string format) {}
-    public string ToString(string format, IFormatProvider formatProvider) {}
-    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null) {}
+    public string ToString(string? format, IFormatProvider? formatProvider) {}
+    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null) {}
     public bool TryWriteBytes(Span<byte> destination, bool asBigEndian) {}
     public void WriteBytes(Span<byte> destination, bool asBigEndian) {}
   }
@@ -175,12 +176,12 @@ namespace Smdn.Formats.UniversallyUniqueIdentifiers {
     IFormattable
   {
     public static Node CreateRandom() {}
-    public static Node Parse(ReadOnlySpan<char> s, IFormatProvider provider = null) {}
-    public static Node Parse(string s, IFormatProvider provider = null) {}
-    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider provider, out Node result) {}
+    public static Node Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null) {}
+    public static Node Parse(string s, IFormatProvider? provider = null) {}
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Node result) {}
     public static bool TryParse(ReadOnlySpan<char> s, out Node result) {}
-    public static bool TryParse(string s, IFormatProvider provider, out Node result) {}
-    public static bool TryParse(string s, out Node result) {}
+    public static bool TryParse(string? s, IFormatProvider? provider, out Node result) {}
+    public static bool TryParse(string? s, out Node result) {}
     public static bool operator == (Node x, Node y) {}
     public static bool operator > (Node x, Node y) {}
     public static bool operator >= (Node x, Node y) {}
@@ -191,16 +192,16 @@ namespace Smdn.Formats.UniversallyUniqueIdentifiers {
     public Node(PhysicalAddress physicalAddress) {}
 
     public int CompareTo(Node other) {}
-    public int CompareTo(object obj) {}
+    public int CompareTo(object? obj) {}
     public bool Equals(Node other) {}
-    public override bool Equals(object obj) {}
+    public override bool Equals(object? obj) {}
     public override int GetHashCode() {}
     public PhysicalAddress ToPhysicalAddress() {}
     public override string ToString() {}
-    public string ToString(string format, IFormatProvider formatProvider = null) {}
+    public string ToString(string? format, IFormatProvider? formatProvider = null) {}
     public bool TryWriteBytes(Span<byte> destination) {}
     public void WriteBytes(Span<byte> destination) {}
   }
 }
-// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.2.0.0.
+// API list generated by Smdn.Reflection.ReverseGenerating.ListApi.MSBuild.Tasks v1.3.2.0.
 // Smdn.Reflection.ReverseGenerating.ListApi.Core v1.2.0.0 (https://github.com/smdn/Smdn.Reflection.ReverseGenerating)


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #282](https://github.com/smdn/Smdn.Fundamentals/actions/runs/7363178589).

# Release target
- package_target_tag: `new-release/main/Smdn.Fundamental.Uuid-3.2.0`
- package_prevver_ref: `releases/Smdn.Fundamental.Uuid-3.1.1`
- package_prevver_tag: `releases/Smdn.Fundamental.Uuid-3.1.1`
- package_id: `Smdn.Fundamental.Uuid`
- package_id_with_version: `Smdn.Fundamental.Uuid-3.2.0`
- package_version: `3.2.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Fundamental.Uuid-3.2.0-1703926944`
- release_tag: `releases/Smdn.Fundamental.Uuid-3.2.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/d7807ddd115f295da5659234cb585be9`](https://gist.github.com/smdn/d7807ddd115f295da5659234cb585be9)
- artifact_name_nupkg: `Smdn.Fundamental.Uuid.3.2.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Fundamental.Uuid.latest.nuspec
+++ Smdn.Fundamental.Uuid.3.2.0.nuspec
@@ -1,55 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Fundamental.Uuid</id>
-    <version>3.1.1</version>
+    <version>3.2.0</version>
     <title>Smdn.Fundamental.Uuid</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Fundamental.Uuid.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
     <description>Smdn.Fundamental.Uuid.dll</description>
+    <releaseNotes>https://github.com/smdn/Smdn.Fundamentals/releases/tag/releases%2FSmdn.Fundamental.Uuid-3.2.0</releaseNotes>
     <copyright>Copyright © 2021 smdn</copyright>
     <tags>smdn.jp UUID UUIDv1 UUIDv3 UUIDv4 UUIDv5 GUID RFC4122</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="b57b4cba29f01d9537ede2ca39db9abb783b20da" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" commit="7357848de1363dbe011b04607e6d6f97dd2b4e57" />
     <dependencies>
       <group targetFramework=".NETFramework4.5">
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Shim" version="[3.1.4, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
         <dependency id="System.ValueTuple" version="4.5.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETFramework4.6.1">
         <dependency id="Microsoft.Bcl.HashCode" version="1.1.1" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Shim" version="[3.1.4, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="System.ValueTuple" version="4.5.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard1.6">
         <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Shim" version="[3.1.4, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
         <dependency id="System.ValueTuple" version="4.5.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net6.0">
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
       </group>
+      <group targetFramework="net8.0">
+        <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
+      </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Bcl.HashCode" version="1.1.1" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.Shim" version="[3.1.4, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Smdn.Fundamental.Exception" version="[3.0.3, 4.0.0)" exclude="Build,Analyzers" />
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/net45/Smdn.Fundamental.Uuid.dll" target="lib/net45/Smdn.Fundamental.Uuid.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/net45/Smdn.Fundamental.Uuid.xml" target="lib/net45/Smdn.Fundamental.Uuid.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/net461/Smdn.Fundamental.Uuid.dll" target="lib/net461/Smdn.Fundamental.Uuid.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/net461/Smdn.Fundamental.Uuid.xml" target="lib/net461/Smdn.Fundamental.Uuid.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/net6.0/Smdn.Fundamental.Uuid.dll" target="lib/net6.0/Smdn.Fundamental.Uuid.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/net6.0/Smdn.Fundamental.Uuid.xml" target="lib/net6.0/Smdn.Fundamental.Uuid.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/net8.0/Smdn.Fundamental.Uuid.dll" target="lib/net8.0/Smdn.Fundamental.Uuid.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/net8.0/Smdn.Fundamental.Uuid.xml" target="lib/net8.0/Smdn.Fundamental.Uuid.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/netstandard1.6/Smdn.Fundamental.Uuid.dll" target="lib/netstandard1.6/Smdn.Fundamental.Uuid.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/netstandard1.6/Smdn.Fundamental.Uuid.xml" target="lib/netstandard1.6/Smdn.Fundamental.Uuid.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/netstandard2.0/Smdn.Fundamental.Uuid.dll" target="lib/netstandard2.0/Smdn.Fundamental.Uuid.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/netstandard2.0/Smdn.Fundamental.Uuid.xml" target="lib/netstandard2.0/Smdn.Fundamental.Uuid.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/netstandard2.1/Smdn.Fundamental.Uuid.dll" target="lib/netstandard2.1/Smdn.Fundamental.Uuid.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/netstandard2.1/Smdn.Fundamental.Uuid.xml" target="lib/netstandard2.1/Smdn.Fundamental.Uuid.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.Fundamental.Uuid.png" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Fundamental.Uuid/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

