### PR TITLE
Release main/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5

### DIFF
--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net45.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net45.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net45'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net451.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net451.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net451'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net452.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net452.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net452'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net46.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net46.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net46'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net461.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net461.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net461'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net462.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net462.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net462'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net47.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net47.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net47'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net471.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net471.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net471'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net472.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net472.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net472'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net48.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net48.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net48'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net481.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net481.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net481'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net5.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net5.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net5.0'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)
@@ -362,3 +362,4 @@
 #define SYSTEM_XML_XMLDOCUMENT_VALIDATE // System.Xml.XmlDocument.Validate (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLDOCUMENT_XMLRESOLVER // System.Xml.XmlDocument.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLRESOLVER // System.Xml.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
+#define SYSTEM_XML_LINQ_XNODE_WRITETOASYNC // System.Xml.Linq.XNode.WriteToAsync (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net6.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net6.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net6.0'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)
@@ -423,3 +423,4 @@
 #define SYSTEM_XML_XMLDOCUMENT_VALIDATE // System.Xml.XmlDocument.Validate (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLDOCUMENT_XMLRESOLVER // System.Xml.XmlDocument.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLRESOLVER // System.Xml.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
+#define SYSTEM_XML_LINQ_XNODE_WRITETOASYNC // System.Xml.Linq.XNode.WriteToAsync (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net7.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net7.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net7.0'
 #define GENERIC_MATH_INTERFACES // System.Numerics (NET7_0_OR_GREATER)
@@ -502,3 +502,4 @@
 #define SYSTEM_XML_XMLDOCUMENT_VALIDATE // System.Xml.XmlDocument.Validate (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLDOCUMENT_XMLRESOLVER // System.Xml.XmlDocument.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLRESOLVER // System.Xml.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
+#define SYSTEM_XML_LINQ_XNODE_WRITETOASYNC // System.Xml.Linq.XNode.WriteToAsync (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net8.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net8.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'net8.0'
 #define GENERIC_MATH_INTERFACES // System.Numerics (NET7_0_OR_GREATER)
@@ -537,3 +537,4 @@
 #define SYSTEM_XML_XMLDOCUMENT_VALIDATE // System.Xml.XmlDocument.Validate (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLDOCUMENT_XMLRESOLVER // System.Xml.XmlDocument.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLRESOLVER // System.Xml.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
+#define SYSTEM_XML_LINQ_XNODE_WRITETOASYNC // System.Xml.Linq.XNode.WriteToAsync (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp1.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp1.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netcoreapp1.0'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp1.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp1.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netcoreapp1.1'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp2.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp2.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netcoreapp2.0'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)
@@ -211,3 +211,4 @@
 #define SYSTEM_XML_XMLDOCUMENT_VALIDATE // System.Xml.XmlDocument.Validate (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLDOCUMENT_XMLRESOLVER // System.Xml.XmlDocument.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLRESOLVER // System.Xml.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
+#define SYSTEM_XML_LINQ_XNODE_WRITETOASYNC // System.Xml.Linq.XNode.WriteToAsync (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp2.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp2.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netcoreapp2.1'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)
@@ -271,3 +271,4 @@
 #define SYSTEM_XML_XMLDOCUMENT_VALIDATE // System.Xml.XmlDocument.Validate (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLDOCUMENT_XMLRESOLVER // System.Xml.XmlDocument.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLRESOLVER // System.Xml.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
+#define SYSTEM_XML_LINQ_XNODE_WRITETOASYNC // System.Xml.Linq.XNode.WriteToAsync (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp3.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp3.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netcoreapp3.0'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)
@@ -303,3 +303,4 @@
 #define SYSTEM_XML_XMLDOCUMENT_VALIDATE // System.Xml.XmlDocument.Validate (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLDOCUMENT_XMLRESOLVER // System.Xml.XmlDocument.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLRESOLVER // System.Xml.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
+#define SYSTEM_XML_LINQ_XNODE_WRITETOASYNC // System.Xml.Linq.XNode.WriteToAsync (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp3.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp3.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netcoreapp3.1'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)
@@ -303,3 +303,4 @@
 #define SYSTEM_XML_XMLDOCUMENT_VALIDATE // System.Xml.XmlDocument.Validate (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLDOCUMENT_XMLRESOLVER // System.Xml.XmlDocument.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLRESOLVER // System.Xml.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
+#define SYSTEM_XML_LINQ_XNODE_WRITETOASYNC // System.Xml.Linq.XNode.WriteToAsync (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netstandard1.0'
 #define SYSTEM_ENUM_TRYPARSE_OF_TENUM // System.Enum.TryParse<TEnum> (NETFRAMEWORK || NETSTANDARD1_0_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netstandard1.1'
 #define SYSTEM_ENUM_TRYPARSE_OF_TENUM // System.Enum.TryParse<TEnum> (NETFRAMEWORK || NETSTANDARD1_0_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.2.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.2.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netstandard1.2'
 #define SYSTEM_ENUM_TRYPARSE_OF_TENUM // System.Enum.TryParse<TEnum> (NETFRAMEWORK || NETSTANDARD1_0_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.3.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.3.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netstandard1.3'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.4.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.4.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netstandard1.4'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.5.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.5.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netstandard1.5'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.6.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.6.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netstandard1.6'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard2.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard2.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netstandard2.0'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard2.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard2.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.4
+//   InformationalVersion: 1.4.5
 
 // List of symbols defined on target framework 'netstandard2.1'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)
@@ -281,3 +281,4 @@
 #define SYSTEM_XML_XMLDOCUMENT_VALIDATE // System.Xml.XmlDocument.Validate (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLDOCUMENT_XMLRESOLVER // System.Xml.XmlDocument.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_XML_XMLRESOLVER // System.Xml.XmlResolver (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
+#define SYSTEM_XML_LINQ_XNODE_WRITETOASYNC // System.Xml.Linq.XNode.WriteToAsync (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #289](https://github.com/smdn/Smdn.Fundamentals/actions/runs/8233453775).

# Release target
- package_target_tag: `new-release/main/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5`
- package_prevver_ref: `releases/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4`
- package_prevver_tag: `releases/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.4`
- package_id: `Smdn.MSBuild.DefineConstants.NETSdkApi`
- package_id_with_version: `Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5`
- package_version: `1.4.5`
- package_branch: `main`
- release_working_branch: `releases/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5-1710162939`
- release_tag: `releases/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.5`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/d00831768c4822506a7571d3abd00013`](https://gist.github.com/smdn/d00831768c4822506a7571d3abd00013)
- artifact_name_nupkg: `Smdn.MSBuild.DefineConstants.NETSdkApi.1.4.5.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.MSBuild.DefineConstants.NETSdkApi.latest.nuspec
+++ Smdn.MSBuild.DefineConstants.NETSdkApi.1.4.5.nuspec
@@ -1,20 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Smdn.MSBuild.DefineConstants.NETSdkApi</id>
-    <version>1.4.4</version>
+    <version>1.4.5</version>
     <title>Smdn.MSBuild.DefineConstants.NETSdkApi</title>
     <authors>smdn</authors>
     <developmentDependency>true</developmentDependency>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.MSBuild.DefineConstants.NETSdkApi.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
     <description>A package of .targets files to add DefineConstants corresponding to .NET SDK's API catalog.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Fundamentals/releases/tag/releases%2FSmdn.MSBuild.DefineConstants.NETSdkApi-1.4.4</releaseNotes>
-    <copyright>Copyright � 2022 smdn</copyright>
+    <releaseNotes>https://github.com/smdn/Smdn.Fundamentals/releases/tag/releases%2FSmdn.MSBuild.DefineConstants.NETSdkApi-1.4.5</releaseNotes>
+    <copyright>Copyright © 2022 smdn</copyright>
     <tags>smdn.jp MSBuild DefineConstants targets build-assets</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="67672a07f8fb727743ec4ec90ff6eb451ac73808" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" commit="c56dea5b187cb907cc1c96d9607cec7cde361f90" />
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.MSBuild.DefineConstants.NETSdkApi.png" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.MSBuild.DefineConstants.NETSdkApi/build/Smdn.MSBuild.DefineConstants.NETSdkApi.targets" target="build/Smdn.MSBuild.DefineConstants.NETSdkApi.targets" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.MSBuild.DefineConstants.NETSdkApi/bin/Release/netstandard1.6/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

