### PR TITLE
Release main/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8

### DIFF
--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net45.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net45.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net45'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net451.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net451.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net451'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net452.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net452.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net452'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net46.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net46.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net46'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net461.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net461.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net461'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net462.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net462.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net462'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net47.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net47.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net47'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net471.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net471.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net471'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net472.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net472.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net472'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net48.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net48.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net48'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net481.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net481.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net481'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net5.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net5.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net5.0'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)
@@ -241,6 +241,7 @@
 #define SYSTEM_NET_MAIL_MAILADDRESS_TRYCREATE // System.Net.Mail.MailAddress.TryCreate (NET5_0_OR_GREATER)
 #define SYSTEM_NET_NETWORKINFORMATION_PHYSICALADDRESS // System.Net.NetworkInformation.PhysicalAddress (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_NET_NETWORKINFORMATION_PHYSICALADDRESS_TRYPARSE // System.Net.NetworkInformation.PhysicalAddress.TryParse (NET5_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_TCPCLIENT_CONNECTASYNC_CANCELLATIONTOKEN // System.Net.Sockets.TcpClient.ConnectAsync(CancellationToken) (NET5_0_OR_GREATER)
 #define SYSTEM_NUMERICS_BITOPERATIONS_LEADINGZEROCOUNT // System.Numerics.BitOperations.LeadingZeroCount (NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_NUMERICS_BITOPERATIONS_LOG2 // System.Numerics.BitOperations.Log2 (NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_NUMERICS_BITOPERATIONS_POPCOUNT // System.Numerics.BitOperations.PopCount (NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net6.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net6.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net6.0'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)
@@ -290,6 +290,11 @@
 #define SYSTEM_NET_SOCKETS_SOCKET_CONNECTASYNC_HOST_PORT_CANCELLATIONTOKEN // System.Net.Sockets.Socket.ConnectAsync(host,port,CancellationToken) (NET6_0_OR_GREATER)
 #define SYSTEM_NET_SOCKETS_SOCKET_CONNECTASYNC_REMOTEEP_CANCELLATIONTOKEN // System.Net.Sockets.Socket.ConnectAsync(remoteEP,CancellationToken) (NET6_0_OR_GREATER)
 #define SYSTEM_NET_SOCKETS_SOCKET_DISCONNECTASYNC_REUSESOCKET_CANCELLATIONTOKEN // System.Net.Sockets.Socket.DisconnectAsync(reuseSocket,cancellationToken) (NET6_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_TCPCLIENT_CONNECTASYNC_CANCELLATIONTOKEN // System.Net.Sockets.TcpClient.ConnectAsync(CancellationToken) (NET5_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_TCPCLIENT_CONNECTASYNC_IPENDPOINT // System.Net.Sockets.TcpClient.ConnectAsync(IPEndPoint) (NET6_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_UDPCLIENT_RECEIVEASYNC_CANCELLATIONTOKEN // System.Net.Sockets.UdpClient.ReceiveAsync(CancellationToken) (NET6_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_UDPCLIENT_SEND_READONLYMEMORY_OF_BYTE // System.Net.Sockets.UdpClient.Send(ReadOnlyMemory<Byte>) (NET6_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_UDPCLIENT_SENDASYNC_READONLYMEMORY_OF_BYTE // System.Net.Sockets.UdpClient.SendAsync(ReadOnlyMemory<Byte>) (NET6_0_OR_GREATER)
 #define SYSTEM_NUMERICS_BITOPERATIONS_ISPOW2 // System.Numerics.BitOperations.IsPow2 (NET6_0_OR_GREATER)
 #define SYSTEM_NUMERICS_BITOPERATIONS_LEADINGZEROCOUNT // System.Numerics.BitOperations.LeadingZeroCount (NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_NUMERICS_BITOPERATIONS_LOG2 // System.Numerics.BitOperations.Log2 (NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net7.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net7.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net7.0'
 #define GENERIC_MATH_INTERFACES // System.Numerics (NET7_0_OR_GREATER)
@@ -314,6 +314,11 @@
 #define SYSTEM_NET_SOCKETS_SOCKET_CONNECTASYNC_HOST_PORT_CANCELLATIONTOKEN // System.Net.Sockets.Socket.ConnectAsync(host,port,CancellationToken) (NET6_0_OR_GREATER)
 #define SYSTEM_NET_SOCKETS_SOCKET_CONNECTASYNC_REMOTEEP_CANCELLATIONTOKEN // System.Net.Sockets.Socket.ConnectAsync(remoteEP,CancellationToken) (NET6_0_OR_GREATER)
 #define SYSTEM_NET_SOCKETS_SOCKET_DISCONNECTASYNC_REUSESOCKET_CANCELLATIONTOKEN // System.Net.Sockets.Socket.DisconnectAsync(reuseSocket,cancellationToken) (NET6_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_TCPCLIENT_CONNECTASYNC_CANCELLATIONTOKEN // System.Net.Sockets.TcpClient.ConnectAsync(CancellationToken) (NET5_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_TCPCLIENT_CONNECTASYNC_IPENDPOINT // System.Net.Sockets.TcpClient.ConnectAsync(IPEndPoint) (NET6_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_UDPCLIENT_RECEIVEASYNC_CANCELLATIONTOKEN // System.Net.Sockets.UdpClient.ReceiveAsync(CancellationToken) (NET6_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_UDPCLIENT_SEND_READONLYMEMORY_OF_BYTE // System.Net.Sockets.UdpClient.Send(ReadOnlyMemory<Byte>) (NET6_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_UDPCLIENT_SENDASYNC_READONLYMEMORY_OF_BYTE // System.Net.Sockets.UdpClient.SendAsync(ReadOnlyMemory<Byte>) (NET6_0_OR_GREATER)
 #define SYSTEM_NUMERICS_BITOPERATIONS_ISPOW2 // System.Numerics.BitOperations.IsPow2 (NET6_0_OR_GREATER)
 #define SYSTEM_NUMERICS_BITOPERATIONS_LEADINGZEROCOUNT // System.Numerics.BitOperations.LeadingZeroCount (NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_NUMERICS_BITOPERATIONS_LOG2 // System.Numerics.BitOperations.Log2 (NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net8.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net8.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'net8.0'
 #define GENERIC_MATH_INTERFACES // System.Numerics (NET7_0_OR_GREATER)
@@ -194,8 +194,11 @@
 #define SYSTEM_BUFFERS_SPANACTION // System.Buffers.SpanAction (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_COLLECTIONS_FROZEN_FROZENDICTIONARY // System.Collections.Frozen.FrozenDictionary (NET8_0_OR_GREATER)
 #define SYSTEM_COLLECTIONS_FROZEN_FROZENSET // System.Collections.Frozen.FrozenSet (NET8_0_OR_GREATER)
+#define SYSTEM_COLLECTIONS_GENERIC_COLLECTIONEXTENSIONS_ADDRANGE // System.Collections.Generic.CollectionExtensions.AddRange (NET8_0_OR_GREATER)
 #define SYSTEM_COLLECTIONS_GENERIC_COLLECTIONEXTENSIONS_ASREADONLY // System.Collections.Generic.CollectionExtensions.AsReadOnly (NET7_0_OR_GREATER)
+#define SYSTEM_COLLECTIONS_GENERIC_COLLECTIONEXTENSIONS_COPYTO // System.Collections.Generic.CollectionExtensions.CopyTo (NET8_0_OR_GREATER)
 #define SYSTEM_COLLECTIONS_GENERIC_COLLECTIONEXTENSIONS_GETVALUEORDEFAULT // System.Collections.Generic.CollectionExtensions.GetValueOrDefault (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
+#define SYSTEM_COLLECTIONS_GENERIC_COLLECTIONEXTENSIONS_INSERTRANGE // System.Collections.Generic.CollectionExtensions.InsertRange (NET8_0_OR_GREATER)
 #define SYSTEM_COLLECTIONS_GENERIC_COLLECTIONEXTENSIONS_REMOVE // System.Collections.Generic.CollectionExtensions.Remove (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_COLLECTIONS_GENERIC_COLLECTIONEXTENSIONS_TRYADD // System.Collections.Generic.CollectionExtensions.TryAdd (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_COLLECTIONS_GENERIC_DICTIONARY_CTOR_IENUMERABLE_OF_KEYVALUEPAIR_OF_TKEY_TVALUE // System.Collections.Generic.Dictionary.ctor(IEnumerable<KeyValuePair<TKey,TValue>>) (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
@@ -333,6 +336,11 @@
 #define SYSTEM_NET_SOCKETS_SOCKET_CONNECTASYNC_HOST_PORT_CANCELLATIONTOKEN // System.Net.Sockets.Socket.ConnectAsync(host,port,CancellationToken) (NET6_0_OR_GREATER)
 #define SYSTEM_NET_SOCKETS_SOCKET_CONNECTASYNC_REMOTEEP_CANCELLATIONTOKEN // System.Net.Sockets.Socket.ConnectAsync(remoteEP,CancellationToken) (NET6_0_OR_GREATER)
 #define SYSTEM_NET_SOCKETS_SOCKET_DISCONNECTASYNC_REUSESOCKET_CANCELLATIONTOKEN // System.Net.Sockets.Socket.DisconnectAsync(reuseSocket,cancellationToken) (NET6_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_TCPCLIENT_CONNECTASYNC_CANCELLATIONTOKEN // System.Net.Sockets.TcpClient.ConnectAsync(CancellationToken) (NET5_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_TCPCLIENT_CONNECTASYNC_IPENDPOINT // System.Net.Sockets.TcpClient.ConnectAsync(IPEndPoint) (NET6_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_UDPCLIENT_RECEIVEASYNC_CANCELLATIONTOKEN // System.Net.Sockets.UdpClient.ReceiveAsync(CancellationToken) (NET6_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_UDPCLIENT_SEND_READONLYMEMORY_OF_BYTE // System.Net.Sockets.UdpClient.Send(ReadOnlyMemory<Byte>) (NET6_0_OR_GREATER)
+#define SYSTEM_NET_SOCKETS_UDPCLIENT_SENDASYNC_READONLYMEMORY_OF_BYTE // System.Net.Sockets.UdpClient.SendAsync(ReadOnlyMemory<Byte>) (NET6_0_OR_GREATER)
 #define SYSTEM_NUMERICS_BITOPERATIONS_CRC32C // System.Numerics.BitOperations.Crc32C (NET8_0_OR_GREATER)
 #define SYSTEM_NUMERICS_BITOPERATIONS_ISPOW2 // System.Numerics.BitOperations.IsPow2 (NET6_0_OR_GREATER)
 #define SYSTEM_NUMERICS_BITOPERATIONS_LEADINGZEROCOUNT // System.Numerics.BitOperations.LeadingZeroCount (NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp1.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp1.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netcoreapp1.0'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp1.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp1.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netcoreapp1.1'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp2.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp2.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netcoreapp2.0'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp2.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp2.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netcoreapp2.1'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp3.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp3.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netcoreapp3.0'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp3.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp3.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netcoreapp3.1'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netstandard1.0'
 #define SYSTEM_ENUM_TRYPARSE_OF_TENUM // System.Enum.TryParse<TEnum> (NETFRAMEWORK || NETSTANDARD1_0_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netstandard1.1'
 #define SYSTEM_ENUM_TRYPARSE_OF_TENUM // System.Enum.TryParse<TEnum> (NETFRAMEWORK || NETSTANDARD1_0_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.2.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.2.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netstandard1.2'
 #define SYSTEM_ENUM_TRYPARSE_OF_TENUM // System.Enum.TryParse<TEnum> (NETFRAMEWORK || NETSTANDARD1_0_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.3.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.3.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netstandard1.3'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.4.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.4.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netstandard1.4'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.5.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.5.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netstandard1.5'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.6.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.6.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netstandard1.6'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard2.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard2.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netstandard2.0'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard2.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard2.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.7
+//   InformationalVersion: 1.4.8
 
 // List of symbols defined on target framework 'netstandard2.1'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #295](https://github.com/smdn/Smdn.Fundamentals/actions/runs/8469264113).

# Release target
- package_target_tag: `new-release/main/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8`
- package_prevver_ref: `releases/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7`
- package_prevver_tag: `releases/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.7`
- package_id: `Smdn.MSBuild.DefineConstants.NETSdkApi`
- package_id_with_version: `Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8`
- package_version: `1.4.8`
- package_branch: `main`
- release_working_branch: `releases/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8-1711637866`
- release_tag: `releases/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/220aa3fd1078b25362efabcc05e6a87a`](https://gist.github.com/smdn/220aa3fd1078b25362efabcc05e6a87a)
- artifact_name_nupkg: `Smdn.MSBuild.DefineConstants.NETSdkApi.1.4.8.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.MSBuild.DefineConstants.NETSdkApi.latest.nuspec
+++ Smdn.MSBuild.DefineConstants.NETSdkApi.1.4.8.nuspec
@@ -1,20 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Smdn.MSBuild.DefineConstants.NETSdkApi</id>
-    <version>1.4.7</version>
+    <version>1.4.8</version>
     <title>Smdn.MSBuild.DefineConstants.NETSdkApi</title>
     <authors>smdn</authors>
     <developmentDependency>true</developmentDependency>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.MSBuild.DefineConstants.NETSdkApi.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
     <description>A package of .targets files to add DefineConstants corresponding to .NET SDK's API catalog.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Fundamentals/releases/tag/releases%2FSmdn.MSBuild.DefineConstants.NETSdkApi-1.4.7</releaseNotes>
-    <copyright>Copyright � 2022 smdn</copyright>
+    <releaseNotes>https://github.com/smdn/Smdn.Fundamentals/releases/tag/releases%2FSmdn.MSBuild.DefineConstants.NETSdkApi-1.4.8</releaseNotes>
+    <copyright>Copyright © 2022 smdn</copyright>
     <tags>smdn.jp MSBuild DefineConstants targets build-assets</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="bd28489df845c293cebf47957cf3cab3959d977c" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" commit="b917603a69a671194d153af9728a129d143f2e9d" />
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.MSBuild.DefineConstants.NETSdkApi.png" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.MSBuild.DefineConstants.NETSdkApi/build/Smdn.MSBuild.DefineConstants.NETSdkApi.targets" target="build/Smdn.MSBuild.DefineConstants.NETSdkApi.targets" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.MSBuild.DefineConstants.NETSdkApi/bin/Release/netstandard1.6/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

