### PR TITLE
Release main/Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0

### DIFF
--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net45.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net45.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net45'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net451.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net451.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net451'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net452.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net452.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net452'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net46.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net46.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net46'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net461.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net461.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net461'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net462.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net462.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net462'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net47.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net47.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net47'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net471.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net471.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net471'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net472.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net472.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net472'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net48.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net48.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net48'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net481.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net481.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net481'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net5.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net5.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net5.0'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net6.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net6.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net6.0'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)
@@ -260,8 +260,24 @@
 #define SYSTEM_IO_COMPRESSION_ZIPARCHIVEENTRY_CRC32 // System.IO.Compression.ZipArchiveEntry.Crc32 (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_IO_COMPRESSION_ZIPARCHIVEENTRY_EXTERNALATTRIBUTES // System.IO.Compression.ZipArchiveEntry.ExternalAttributes (NET472_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_IO_COMPRESSION_ZLIBSTREAM // System.IO.Compression.ZLibStream (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_CHUNK // System.Linq.Enumerable.Chunk (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_DISTINCTBY // System.Linq.Enumerable.DistinctBy (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_ELEMENTAT_INDEX // System.Linq.Enumerable.ElementAt(Index) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_ELEMENTATORDEFAULT_INDEX // System.Linq.Enumerable.ElementAtOrDefault(Index) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_EXCEPTBY // System.Linq.Enumerable.ExceptBy (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_FIRSTORDEFAULT_SOURCE_DEFAULTVALUE // System.Linq.Enumerable.FirstOrDefault(source,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_FIRSTORDEFAULT_SOURCE_PREDICATE_DEFAULTVALUE // System.Linq.Enumerable.FirstOrDefault(source,predicate,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_INTERSECTBY // System.Linq.Enumerable.IntersectBy (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_LASTORDEFAULT_SOURCE_DEFAULTVALUE // System.Linq.Enumerable.LastOrDefault(source,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_LASTORDEFAULT_SOURCE_PREDICATE_DEFAULTVALUE // System.Linq.Enumerable.LastOrDefault(source,predicate,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_MAXBY // System.Linq.Enumerable.MaxBy (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_MINBY // System.Linq.Enumerable.MinBy (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_SINGLEORDEFAULT_SOURCE_DEFAULTVALUE // System.Linq.Enumerable.SingleOrDefault(source,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_SINGLEORDEFAULT_SOURCE_PREDICATE_DEFAULTVALUE // System.Linq.Enumerable.SingleOrDefault(source,predicate,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_TAKE_RANGE // System.Linq.Enumerable.Take(Range) (NET6_0_OR_GREATER)
 #define SYSTEM_LINQ_ENUMERABLE_TOHASHSET // System.Linq.Enumerable.ToHashSet (NET472_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_LINQ_ENUMERABLE_TRYGETNONENUMERATEDCOUNT // System.Linq.Enumerable.TryGetNonEnumeratedCount (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_UNIONBY // System.Linq.Enumerable.UnionBy (NET6_0_OR_GREATER)
 #define SYSTEM_NET_DNS // System.Net.Dns (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_NET_DNS_GETHOSTADDRESSES_HOSTNAMEORADDRESS // System.Net.Dns.GetHostAddresses(hostNameOrAddress) (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_NET_DNS_GETHOSTADDRESSES_HOSTNAMEORADDRESS_FAMILY // System.Net.Dns.GetHostAddresses(hostNameOrAddress,family) (NET6_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net7.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net7.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net7.0'
 #define GENERIC_MATH_INTERFACES // System.Numerics (NET7_0_OR_GREATER)
@@ -282,10 +282,26 @@
 #define SYSTEM_IO_COMPRESSION_ZIPARCHIVEENTRY_CRC32 // System.IO.Compression.ZipArchiveEntry.Crc32 (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_IO_COMPRESSION_ZIPARCHIVEENTRY_EXTERNALATTRIBUTES // System.IO.Compression.ZipArchiveEntry.ExternalAttributes (NET472_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_IO_COMPRESSION_ZLIBSTREAM // System.IO.Compression.ZLibStream (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_CHUNK // System.Linq.Enumerable.Chunk (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_DISTINCTBY // System.Linq.Enumerable.DistinctBy (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_ELEMENTAT_INDEX // System.Linq.Enumerable.ElementAt(Index) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_ELEMENTATORDEFAULT_INDEX // System.Linq.Enumerable.ElementAtOrDefault(Index) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_EXCEPTBY // System.Linq.Enumerable.ExceptBy (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_FIRSTORDEFAULT_SOURCE_DEFAULTVALUE // System.Linq.Enumerable.FirstOrDefault(source,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_FIRSTORDEFAULT_SOURCE_PREDICATE_DEFAULTVALUE // System.Linq.Enumerable.FirstOrDefault(source,predicate,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_INTERSECTBY // System.Linq.Enumerable.IntersectBy (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_LASTORDEFAULT_SOURCE_DEFAULTVALUE // System.Linq.Enumerable.LastOrDefault(source,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_LASTORDEFAULT_SOURCE_PREDICATE_DEFAULTVALUE // System.Linq.Enumerable.LastOrDefault(source,predicate,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_MAXBY // System.Linq.Enumerable.MaxBy (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_MINBY // System.Linq.Enumerable.MinBy (NET6_0_OR_GREATER)
 #define SYSTEM_LINQ_ENUMERABLE_ORDER // System.Linq.Enumerable.Order (NET7_0_OR_GREATER)
 #define SYSTEM_LINQ_ENUMERABLE_ORDERDESCENDING // System.Linq.Enumerable.OrderDescending (NET7_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_SINGLEORDEFAULT_SOURCE_DEFAULTVALUE // System.Linq.Enumerable.SingleOrDefault(source,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_SINGLEORDEFAULT_SOURCE_PREDICATE_DEFAULTVALUE // System.Linq.Enumerable.SingleOrDefault(source,predicate,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_TAKE_RANGE // System.Linq.Enumerable.Take(Range) (NET6_0_OR_GREATER)
 #define SYSTEM_LINQ_ENUMERABLE_TOHASHSET // System.Linq.Enumerable.ToHashSet (NET472_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_LINQ_ENUMERABLE_TRYGETNONENUMERATEDCOUNT // System.Linq.Enumerable.TryGetNonEnumeratedCount (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_UNIONBY // System.Linq.Enumerable.UnionBy (NET6_0_OR_GREATER)
 #define SYSTEM_NET_DNS // System.Net.Dns (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_NET_DNS_GETHOSTADDRESSES_HOSTNAMEORADDRESS // System.Net.Dns.GetHostAddresses(hostNameOrAddress) (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_NET_DNS_GETHOSTADDRESSES_HOSTNAMEORADDRESS_FAMILY // System.Net.Dns.GetHostAddresses(hostNameOrAddress,family) (NET6_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net8.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/net8.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'net8.0'
 #define GENERIC_MATH_INTERFACES // System.Numerics (NET7_0_OR_GREATER)
@@ -303,10 +303,26 @@
 #define SYSTEM_IO_COMPRESSION_ZIPARCHIVEENTRY_CRC32 // System.IO.Compression.ZipArchiveEntry.Crc32 (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_IO_COMPRESSION_ZIPARCHIVEENTRY_EXTERNALATTRIBUTES // System.IO.Compression.ZipArchiveEntry.ExternalAttributes (NET472_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_IO_COMPRESSION_ZLIBSTREAM // System.IO.Compression.ZLibStream (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_CHUNK // System.Linq.Enumerable.Chunk (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_DISTINCTBY // System.Linq.Enumerable.DistinctBy (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_ELEMENTAT_INDEX // System.Linq.Enumerable.ElementAt(Index) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_ELEMENTATORDEFAULT_INDEX // System.Linq.Enumerable.ElementAtOrDefault(Index) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_EXCEPTBY // System.Linq.Enumerable.ExceptBy (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_FIRSTORDEFAULT_SOURCE_DEFAULTVALUE // System.Linq.Enumerable.FirstOrDefault(source,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_FIRSTORDEFAULT_SOURCE_PREDICATE_DEFAULTVALUE // System.Linq.Enumerable.FirstOrDefault(source,predicate,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_INTERSECTBY // System.Linq.Enumerable.IntersectBy (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_LASTORDEFAULT_SOURCE_DEFAULTVALUE // System.Linq.Enumerable.LastOrDefault(source,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_LASTORDEFAULT_SOURCE_PREDICATE_DEFAULTVALUE // System.Linq.Enumerable.LastOrDefault(source,predicate,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_MAXBY // System.Linq.Enumerable.MaxBy (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_MINBY // System.Linq.Enumerable.MinBy (NET6_0_OR_GREATER)
 #define SYSTEM_LINQ_ENUMERABLE_ORDER // System.Linq.Enumerable.Order (NET7_0_OR_GREATER)
 #define SYSTEM_LINQ_ENUMERABLE_ORDERDESCENDING // System.Linq.Enumerable.OrderDescending (NET7_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_SINGLEORDEFAULT_SOURCE_DEFAULTVALUE // System.Linq.Enumerable.SingleOrDefault(source,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_SINGLEORDEFAULT_SOURCE_PREDICATE_DEFAULTVALUE // System.Linq.Enumerable.SingleOrDefault(source,predicate,defaultValue) (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_TAKE_RANGE // System.Linq.Enumerable.Take(Range) (NET6_0_OR_GREATER)
 #define SYSTEM_LINQ_ENUMERABLE_TOHASHSET // System.Linq.Enumerable.ToHashSet (NET472_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_LINQ_ENUMERABLE_TRYGETNONENUMERATEDCOUNT // System.Linq.Enumerable.TryGetNonEnumeratedCount (NET6_0_OR_GREATER)
+#define SYSTEM_LINQ_ENUMERABLE_UNIONBY // System.Linq.Enumerable.UnionBy (NET6_0_OR_GREATER)
 #define SYSTEM_NET_DNS // System.Net.Dns (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_NET_DNS_GETHOSTADDRESSES_HOSTNAMEORADDRESS // System.Net.Dns.GetHostAddresses(hostNameOrAddress) (NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER || NET5_0_OR_GREATER)
 #define SYSTEM_NET_DNS_GETHOSTADDRESSES_HOSTNAMEORADDRESS_FAMILY // System.Net.Dns.GetHostAddresses(hostNameOrAddress,family) (NET6_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp1.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp1.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netcoreapp1.0'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp1.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp1.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netcoreapp1.1'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp2.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp2.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netcoreapp2.0'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp2.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp2.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netcoreapp2.1'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp3.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp3.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netcoreapp3.0'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp3.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netcoreapp3.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netcoreapp3.1'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netstandard1.0'
 #define SYSTEM_ENUM_TRYPARSE_OF_TENUM // System.Enum.TryParse<TEnum> (NETFRAMEWORK || NETSTANDARD1_0_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netstandard1.1'
 #define SYSTEM_ENUM_TRYPARSE_OF_TENUM // System.Enum.TryParse<TEnum> (NETFRAMEWORK || NETSTANDARD1_0_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.2.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.2.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netstandard1.2'
 #define SYSTEM_ENUM_TRYPARSE_OF_TENUM // System.Enum.TryParse<TEnum> (NETFRAMEWORK || NETSTANDARD1_0_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.3.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.3.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netstandard1.3'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.4.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.4.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netstandard1.4'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.5.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.5.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netstandard1.5'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.6.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard1.6.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netstandard1.6'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard2.0.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard2.0.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netstandard2.0'
 #define MICROSOFT_WIN32_REGISTRY // Microsoft.Win32.Registry (NETFRAMEWORK || NETSTANDARD1_3_OR_GREATER || NETCOREAPP1_0_OR_GREATER || NET5_0_OR_GREATER)

--- a/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard2.1.symbols.apilist.cs
+++ b/doc/api-list/Smdn.MSBuild.DefineConstants.NETSdkApi/netstandard2.1.symbols.apilist.cs
@@ -1,6 +1,6 @@
-// Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8
+// Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0
 //   Name: Smdn.MSBuild.DefineConstants.NETSdkApi
-//   InformationalVersion: 1.4.8
+//   InformationalVersion: 1.5.0
 
 // List of symbols defined on target framework 'netstandard2.1'
 #define NULL_STATE_STATIC_ANALYSIS_ATTRIBUTES // System.Diagnostics.CodeAnalysis (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #301](https://github.com/smdn/Smdn.Fundamentals/actions/runs/11666720037).

# Release target
- package_target_tag: `new-release/main/Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0`
- package_prevver_ref: `releases/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8`
- package_prevver_tag: `releases/Smdn.MSBuild.DefineConstants.NETSdkApi-1.4.8`
- package_id: `Smdn.MSBuild.DefineConstants.NETSdkApi`
- package_id_with_version: `Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0`
- package_version: `1.5.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0-1730732070`
- release_tag: `releases/Smdn.MSBuild.DefineConstants.NETSdkApi-1.5.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/478b36c34b9062ce72fc2bf9116b0af8`](https://gist.github.com/smdn/478b36c34b9062ce72fc2bf9116b0af8)
- artifact_name_nupkg: `Smdn.MSBuild.DefineConstants.NETSdkApi.1.5.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.MSBuild.DefineConstants.NETSdkApi.latest.nuspec
+++ Smdn.MSBuild.DefineConstants.NETSdkApi.1.5.0.nuspec
@@ -1,20 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Smdn.MSBuild.DefineConstants.NETSdkApi</id>
-    <version>1.4.8</version>
+    <version>1.5.0</version>
     <title>Smdn.MSBuild.DefineConstants.NETSdkApi</title>
     <authors>smdn</authors>
     <developmentDependency>true</developmentDependency>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.MSBuild.DefineConstants.NETSdkApi.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
     <description>A package of .targets files to add DefineConstants corresponding to .NET SDK's API catalog.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Fundamentals/releases/tag/releases%2FSmdn.MSBuild.DefineConstants.NETSdkApi-1.4.8</releaseNotes>
-    <copyright>Copyright � 2022 smdn</copyright>
+    <releaseNotes>https://github.com/smdn/Smdn.Fundamentals/releases/tag/releases%2FSmdn.MSBuild.DefineConstants.NETSdkApi-1.5.0</releaseNotes>
+    <copyright>Copyright © 2022 smdn</copyright>
     <tags>smdn.jp MSBuild DefineConstants targets build-assets</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="b917603a69a671194d153af9728a129d143f2e9d" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" commit="300bc47a8e6f46d606804a3d2b228200ab10ac79" />
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.MSBuild.DefineConstants.NETSdkApi.png" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.MSBuild.DefineConstants.NETSdkApi/build/Smdn.MSBuild.DefineConstants.NETSdkApi.targets" target="build/Smdn.MSBuild.DefineConstants.NETSdkApi.targets" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.MSBuild.DefineConstants.NETSdkApi/bin/Release/netstandard1.6/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

