### PR TITLE
Release main/Smdn.Extensions.Polly.KeyedRegistry-1.2.0

### DIFF
--- a/doc/api-list/Smdn.Extensions.Polly.KeyedRegistry/Smdn.Extensions.Polly.KeyedRegistry-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.Extensions.Polly.KeyedRegistry/Smdn.Extensions.Polly.KeyedRegistry-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Extensions.Polly.KeyedRegistry.dll (Smdn.Extensions.Polly.KeyedRegistry-1.1.0)
+// Smdn.Extensions.Polly.KeyedRegistry.dll (Smdn.Extensions.Polly.KeyedRegistry-1.2.0)
 //   Name: Smdn.Extensions.Polly.KeyedRegistry
-//   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0+eb9d40b54434eddcd353ae4ebaf93e0ec0cf76dd
+//   AssemblyVersion: 1.2.0.0
+//   InformationalVersion: 1.2.0+ab57871a61fa98809fd1f62940e326073110502c
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -9,9 +9,11 @@
 //     Polly.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
 //     Polly.Extensions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc
 //     System.ComponentModel, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Linq, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 //     System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 #nullable enable annotations
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Polly;
@@ -25,6 +27,10 @@ namespace Polly {
     public static IServiceCollection AddResiliencePipeline<TResiliencePipelineKeyPair, TServiceKey, TPipelineKey>(this IServiceCollection services, TServiceKey serviceKey, TPipelineKey pipelineKey, Func<TServiceKey, TPipelineKey, TResiliencePipelineKeyPair> createResiliencePipelineKeyPair, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<TResiliencePipelineKeyPair>> configure) where TResiliencePipelineKeyPair : notnull, IResiliencePipelineKeyPair<TServiceKey, TPipelineKey> where TPipelineKey : notnull {}
     public static IServiceCollection AddResiliencePipeline<TResiliencePipelineKeyPair, TServiceKey, TPipelineKey>(this IServiceCollection services, TServiceKey serviceKey, TPipelineKey pipelineKey, Func<TServiceKey, TPipelineKey, TResiliencePipelineKeyPair> createResiliencePipelineKeyPair, Action<ResiliencePipelineRegistryOptions<TResiliencePipelineKeyPair>>? configureRegistryOptions, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<TResiliencePipelineKeyPair>> configurePipeline) where TResiliencePipelineKeyPair : notnull, IResiliencePipelineKeyPair<TServiceKey, TPipelineKey> where TPipelineKey : notnull {}
     public static IServiceCollection AddResiliencePipeline<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TResiliencePipelineKeyPair, TServiceKey, TPipelineKey>(this IServiceCollection services, TResiliencePipelineKeyPair resiliencePipelineKeyPair, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<TResiliencePipelineKeyPair>> configure) where TResiliencePipelineKeyPair : notnull, IResiliencePipelineKeyPair<TServiceKey, TPipelineKey> where TPipelineKey : notnull {}
+  }
+
+  public static class KeyedResiliencePipelineProviderServiceProviderExtensions {
+    public static ResiliencePipelineProvider<TPipelineKey>? GetKeyedResiliencePipelineProvider<TPipelineKey>(this IServiceProvider serviceProvider, object? serviceKey, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type typeOfKeyPair) where TPipelineKey : notnull {}
   }
 }
 

--- a/doc/api-list/Smdn.Extensions.Polly.KeyedRegistry/Smdn.Extensions.Polly.KeyedRegistry-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Extensions.Polly.KeyedRegistry/Smdn.Extensions.Polly.KeyedRegistry-netstandard2.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Extensions.Polly.KeyedRegistry.dll (Smdn.Extensions.Polly.KeyedRegistry-1.1.0)
+// Smdn.Extensions.Polly.KeyedRegistry.dll (Smdn.Extensions.Polly.KeyedRegistry-1.2.0)
 //   Name: Smdn.Extensions.Polly.KeyedRegistry
-//   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0+eb9d40b54434eddcd353ae4ebaf93e0ec0cf76dd
+//   AssemblyVersion: 1.2.0.0
+//   InformationalVersion: 1.2.0+ab57871a61fa98809fd1f62940e326073110502c
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -11,6 +11,7 @@
 //     netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 #nullable enable annotations
 
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Polly;
 using Polly.Registry;
@@ -23,6 +24,10 @@ namespace Polly {
     public static IServiceCollection AddResiliencePipeline<TResiliencePipelineKeyPair, TServiceKey, TPipelineKey>(this IServiceCollection services, TResiliencePipelineKeyPair resiliencePipelineKeyPair, Func<TServiceKey, TPipelineKey, TResiliencePipelineKeyPair> createResiliencePipelineKeyPair, Action<ResiliencePipelineRegistryOptions<TResiliencePipelineKeyPair>>? configureRegistryOptions, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<TResiliencePipelineKeyPair>> configurePipeline) where TResiliencePipelineKeyPair : notnull, IResiliencePipelineKeyPair<TServiceKey, TPipelineKey> where TPipelineKey : notnull {}
     public static IServiceCollection AddResiliencePipeline<TResiliencePipelineKeyPair, TServiceKey, TPipelineKey>(this IServiceCollection services, TServiceKey serviceKey, TPipelineKey pipelineKey, Func<TServiceKey, TPipelineKey, TResiliencePipelineKeyPair> createResiliencePipelineKeyPair, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<TResiliencePipelineKeyPair>> configure) where TResiliencePipelineKeyPair : notnull, IResiliencePipelineKeyPair<TServiceKey, TPipelineKey> where TPipelineKey : notnull {}
     public static IServiceCollection AddResiliencePipeline<TResiliencePipelineKeyPair, TServiceKey, TPipelineKey>(this IServiceCollection services, TServiceKey serviceKey, TPipelineKey pipelineKey, Func<TServiceKey, TPipelineKey, TResiliencePipelineKeyPair> createResiliencePipelineKeyPair, Action<ResiliencePipelineRegistryOptions<TResiliencePipelineKeyPair>>? configureRegistryOptions, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<TResiliencePipelineKeyPair>> configurePipeline) where TResiliencePipelineKeyPair : notnull, IResiliencePipelineKeyPair<TServiceKey, TPipelineKey> where TPipelineKey : notnull {}
+  }
+
+  public static class KeyedResiliencePipelineProviderServiceProviderExtensions {
+    public static ResiliencePipelineProvider<TPipelineKey>? GetKeyedResiliencePipelineProvider<TPipelineKey>(this IServiceProvider serviceProvider, object? serviceKey, Type typeOfKeyPair) where TPipelineKey : notnull {}
   }
 }
 

--- a/doc/api-list/Smdn.Extensions.Polly.KeyedRegistry/Smdn.Extensions.Polly.KeyedRegistry-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.Extensions.Polly.KeyedRegistry/Smdn.Extensions.Polly.KeyedRegistry-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.Extensions.Polly.KeyedRegistry.dll (Smdn.Extensions.Polly.KeyedRegistry-1.1.0)
+// Smdn.Extensions.Polly.KeyedRegistry.dll (Smdn.Extensions.Polly.KeyedRegistry-1.2.0)
 //   Name: Smdn.Extensions.Polly.KeyedRegistry
-//   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0+eb9d40b54434eddcd353ae4ebaf93e0ec0cf76dd
+//   AssemblyVersion: 1.2.0.0
+//   InformationalVersion: 1.2.0+ab57871a61fa98809fd1f62940e326073110502c
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -11,6 +11,7 @@
 //     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 #nullable enable annotations
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Polly;
@@ -24,6 +25,10 @@ namespace Polly {
     public static IServiceCollection AddResiliencePipeline<TResiliencePipelineKeyPair, TServiceKey, TPipelineKey>(this IServiceCollection services, TResiliencePipelineKeyPair resiliencePipelineKeyPair, Func<TServiceKey, TPipelineKey, TResiliencePipelineKeyPair> createResiliencePipelineKeyPair, Action<ResiliencePipelineRegistryOptions<TResiliencePipelineKeyPair>>? configureRegistryOptions, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<TResiliencePipelineKeyPair>> configurePipeline) where TResiliencePipelineKeyPair : notnull, IResiliencePipelineKeyPair<TServiceKey, TPipelineKey> where TPipelineKey : notnull {}
     public static IServiceCollection AddResiliencePipeline<TResiliencePipelineKeyPair, TServiceKey, TPipelineKey>(this IServiceCollection services, TServiceKey serviceKey, TPipelineKey pipelineKey, Func<TServiceKey, TPipelineKey, TResiliencePipelineKeyPair> createResiliencePipelineKeyPair, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<TResiliencePipelineKeyPair>> configure) where TResiliencePipelineKeyPair : notnull, IResiliencePipelineKeyPair<TServiceKey, TPipelineKey> where TPipelineKey : notnull {}
     public static IServiceCollection AddResiliencePipeline<TResiliencePipelineKeyPair, TServiceKey, TPipelineKey>(this IServiceCollection services, TServiceKey serviceKey, TPipelineKey pipelineKey, Func<TServiceKey, TPipelineKey, TResiliencePipelineKeyPair> createResiliencePipelineKeyPair, Action<ResiliencePipelineRegistryOptions<TResiliencePipelineKeyPair>>? configureRegistryOptions, Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<TResiliencePipelineKeyPair>> configurePipeline) where TResiliencePipelineKeyPair : notnull, IResiliencePipelineKeyPair<TServiceKey, TPipelineKey> where TPipelineKey : notnull {}
+  }
+
+  public static class KeyedResiliencePipelineProviderServiceProviderExtensions {
+    public static ResiliencePipelineProvider<TPipelineKey>? GetKeyedResiliencePipelineProvider<TPipelineKey>(this IServiceProvider serviceProvider, object? serviceKey, Type typeOfKeyPair) where TPipelineKey : notnull {}
   }
 }
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #311](https://github.com/smdn/Smdn.Fundamentals/actions/runs/15649367674).

# Release target
- package_target_tag: `new-release/main/Smdn.Extensions.Polly.KeyedRegistry-1.2.0`
- package_prevver_ref: `releases/Smdn.Extensions.Polly.KeyedRegistry-1.1.0`
- package_prevver_tag: `releases/Smdn.Extensions.Polly.KeyedRegistry-1.1.0`
- package_id: `Smdn.Extensions.Polly.KeyedRegistry`
- package_id_with_version: `Smdn.Extensions.Polly.KeyedRegistry-1.2.0`
- package_version: `1.2.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Extensions.Polly.KeyedRegistry-1.2.0-1749883047`
- release_tag: `releases/Smdn.Extensions.Polly.KeyedRegistry-1.2.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/f5f071a866070ffab2a3a39a02ae3892`](https://gist.github.com/smdn/f5f071a866070ffab2a3a39a02ae3892)
- artifact_name_nupkg: `Smdn.Extensions.Polly.KeyedRegistry.1.2.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.Extensions.Polly.KeyedRegistry.latest.nuspec
+++ Smdn.Extensions.Polly.KeyedRegistry.1.2.0.nuspec
@@ -1,33 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.Extensions.Polly.KeyedRegistry</id>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <title>Smdn.Extensions.Polly.KeyedRegistry</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.Extensions.Polly.KeyedRegistry.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://smdn.jp/works/libs/Smdn.Fundamentals/</projectUrl>
     <description>Provides the extensions to enable the registration of the `ResiliencePipelineProvider&lt;TKey&gt;` with the service key to the `ServiceCollection`. This enables multiple `ResiliencePipelineProvider`s targeting the same type to be registered and to be retrieved individually by specifying the service key.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.Fundamentals/releases/tag/releases%2FSmdn.Extensions.Polly.KeyedRegistry-1.1.0</releaseNotes>
-    <copyright>Copyright � 2025 smdn</copyright>
+    <releaseNotes>https://github.com/smdn/Smdn.Fundamentals/releases/tag/releases%2FSmdn.Extensions.Polly.KeyedRegistry-1.2.0</releaseNotes>
+    <copyright>Copyright © 2025 smdn</copyright>
     <tags>smdn.jp Polly extensions dependency-injection keyed-service</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" branch="main" commit="eb9d40b54434eddcd353ae4ebaf93e0ec0cf76dd" />
+    <repository type="git" url="https://github.com/smdn/Smdn.Fundamentals" commit="ab57871a61fa98809fd1f62940e326073110502c" />
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Extensions" version="8.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Extensions" version="8.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="Polly.Extensions" version="8.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Extensions.Polly.KeyedRegistry/bin/Release/net8.0/Smdn.Extensions.Polly.KeyedRegistry.dll" target="lib/net8.0/Smdn.Extensions.Polly.KeyedRegistry.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Extensions.Polly.KeyedRegistry/bin/Release/net8.0/Smdn.Extensions.Polly.KeyedRegistry.xml" target="lib/net8.0/Smdn.Extensions.Polly.KeyedRegistry.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Extensions.Polly.KeyedRegistry/bin/Release/netstandard2.0/Smdn.Extensions.Polly.KeyedRegistry.dll" target="lib/netstandard2.0/Smdn.Extensions.Polly.KeyedRegistry.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Extensions.Polly.KeyedRegistry/bin/Release/netstandard2.0/Smdn.Extensions.Polly.KeyedRegistry.xml" target="lib/netstandard2.0/Smdn.Extensions.Polly.KeyedRegistry.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Extensions.Polly.KeyedRegistry/bin/Release/netstandard2.1/Smdn.Extensions.Polly.KeyedRegistry.dll" target="lib/netstandard2.1/Smdn.Extensions.Polly.KeyedRegistry.dll" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Extensions.Polly.KeyedRegistry/bin/Release/netstandard2.1/Smdn.Extensions.Polly.KeyedRegistry.xml" target="lib/netstandard2.1/Smdn.Extensions.Polly.KeyedRegistry.xml" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/.nuget/packages/smdn.msbuild.projectassets.common/1.4.1/project/images/package-icon.png" target="Smdn.Extensions.Polly.KeyedRegistry.png" />
+    <file src="/home/runner/work/Smdn.Fundamentals/Smdn.Fundamentals/src/Smdn.Extensions.Polly.KeyedRegistry/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

